### PR TITLE
Fix escrow DoS Attack

### DIFF
--- a/contracts/cw20-escrow/schema/details_response.json
+++ b/contracts/cw20-escrow/schema/details_response.json
@@ -5,6 +5,7 @@
   "required": [
     "arbiter",
     "cw20_balance",
+    "cw20_whitelist",
     "id",
     "native_balance",
     "recipient",
@@ -24,6 +25,13 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/Cw20CoinHuman"
+      }
+    },
+    "cw20_whitelist": {
+      "description": "Whitelisted cw20 tokens",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/HumanAddr"
       }
     },
     "end_height": {

--- a/contracts/cw20-escrow/schema/handle_msg.json
+++ b/contracts/cw20-escrow/schema/handle_msg.json
@@ -109,6 +109,16 @@
             }
           ]
         },
+        "cw20_whitelist": {
+          "description": "Besides any possible tokens sent with the CreateMsg, this is a list of all cw20 token addresses that are accepted by the escrow during a top-up. This is required to avoid a DoS attack by topping-up with an invalid cw20 contract. See https://github.com/CosmWasm/cosmwasm-plus/issues/19",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/HumanAddr"
+          }
+        },
         "end_height": {
           "description": "When end height set and block height exceeds this value, the escrow is expired. Once an escrow is expired, it can be returned to the original funder (via \"refund\").",
           "type": [

--- a/contracts/cw20-escrow/schema/receive_msg.json
+++ b/contracts/cw20-escrow/schema/receive_msg.json
@@ -51,6 +51,16 @@
             }
           ]
         },
+        "cw20_whitelist": {
+          "description": "Besides any possible tokens sent with the CreateMsg, this is a list of all cw20 token addresses that are accepted by the escrow during a top-up. This is required to avoid a DoS attack by topping-up with an invalid cw20 contract. See https://github.com/CosmWasm/cosmwasm-plus/issues/19",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/HumanAddr"
+          }
+        },
         "end_height": {
           "description": "When end height set and block height exceeds this value, the escrow is expired. Once an escrow is expired, it can be returned to the original funder (via \"refund\").",
           "type": [

--- a/contracts/cw20-escrow/src/msg.rs
+++ b/contracts/cw20-escrow/src/msg.rs
@@ -116,6 +116,8 @@ pub struct DetailsResponse {
     pub native_balance: Vec<Coin>,
     /// Balance in cw20 tokens
     pub cw20_balance: Vec<Cw20CoinHuman>,
+    /// Whitelisted cw20 tokens
+    pub cw20_whitelist: Vec<HumanAddr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/cw20-escrow/src/msg.rs
+++ b/contracts/cw20-escrow/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, HumanAddr, Uint128};
+use cosmwasm_std::{Api, CanonicalAddr, Coin, HumanAddr, StdResult, Uint128};
 use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -56,6 +56,19 @@ pub struct CreateMsg {
     /// block time exceeds this value, the escrow is expired.
     /// Once an escrow is expired, it can be returned to the original funder (via "refund").
     pub end_time: Option<u64>,
+    /// Besides any possible tokens sent with the CreateMsg, this is a list of all cw20 token addresses
+    /// that are accepted by the escrow during a top-up. This is required to avoid a DoS attack by topping-up
+    /// with an invalid cw20 contract. See https://github.com/CosmWasm/cosmwasm-plus/issues/19
+    pub cw20_whitelist: Option<Vec<HumanAddr>>,
+}
+
+impl CreateMsg {
+    pub fn canonical_whitelist<A: Api>(&self, api: &A) -> StdResult<Vec<CanonicalAddr>> {
+        match self.cw20_whitelist.as_ref() {
+            Some(v) => v.iter().map(|h| api.canonical_address(h)).collect(),
+            None => Ok(vec![]),
+        }
+    }
 }
 
 pub fn is_valid_name(name: &str) -> bool {

--- a/contracts/cw20-escrow/src/state.rs
+++ b/contracts/cw20-escrow/src/state.rs
@@ -25,6 +25,8 @@ pub struct Escrow {
     pub native_balance: Vec<Coin>,
     /// Balance in cw20 tokens
     pub cw20_balance: Vec<Cw20Coin>,
+    /// All possible contracts that we accept tokens from
+    pub cw20_whitelist: Vec<CanonicalAddr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/cw20-escrow/src/state.rs
+++ b/contracts/cw20-escrow/src/state.rs
@@ -2,7 +2,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    CanonicalAddr, Coin, Env, Order, ReadonlyStorage, StdError, StdResult, Storage, Uint128,
+    Api, CanonicalAddr, Coin, Env, HumanAddr, Order, ReadonlyStorage, StdError, StdResult, Storage,
+    Uint128,
 };
 use cosmwasm_storage::{bucket, bucket_read, prefixed_read, Bucket, ReadonlyBucket};
 
@@ -50,6 +51,13 @@ impl Escrow {
         }
 
         false
+    }
+
+    pub fn human_whitelist<A: Api>(&self, api: &A) -> StdResult<Vec<HumanAddr>> {
+        self.cw20_whitelist
+            .iter()
+            .map(|h| api.human_address(h))
+            .collect()
     }
 }
 


### PR DESCRIPTION
Closes #19 

Implements an optional whitelist on CreateMsg if you want to accept any tokens that were not used during creation. Can often be omitted from JSON without any negative effect (use Option, so no need for empty array client side)