### PR TITLE
Implement subkeys as a cw1 contract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
 jobs:
   contract_cw1_subkeys:
     docker:
-      - image: rust:1.44.0
+      - image: rust:1.44.1
     working_directory: ~/project/contracts/cw1-subkeys
     steps:
       - checkout:
@@ -24,7 +24,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw1-subkeys-rust:1.44.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw1-subkeys-rust:1.44.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -51,7 +51,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw1-subkeys-rust:1.44.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw1-subkeys-rust:1.44.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw1_whitelist:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - contract_cw1_subkeys
       - contract_cw1_whitelist
       - contract_cw20_base
       - contract_cw20_escrow
@@ -11,6 +12,47 @@ workflows:
       - lint
 
 jobs:
+  contract_cw1_subkeys:
+    docker:
+      - image: rust:1.44.0
+    working_directory: ~/project/contracts/cw1-subkeys
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version
+      - restore_cache:
+          keys:
+            - cargocache-cw1-subkeys-rust:1.44.0-{{ checksum "~/project/Cargo.lock" }}
+      - run:
+          name: Add wasm32 target
+          command: rustup target add wasm32-unknown-unknown
+      - run:
+          name: Unit Tests
+          env: RUST_BACKTRACE=1
+          command: cargo unit-test --locked
+      - run:
+          name: Build Wasm
+          command: cargo wasm-debug --locked
+      - run:
+          name: Build and run schema generator
+          command: cargo schema --locked
+      - run:
+          name: Ensure checked-in schemas are up-to-date
+          command: |
+            CHANGES_IN_REPO=$(git status --porcelain)
+            if [[ -n "$CHANGES_IN_REPO" ]]; then
+              echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+              git status && git --no-pager diff
+              exit 1
+            fi
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target
+          key: cargocache-cw1-subkeys-rust:1.44.0-{{ checksum "~/project/Cargo.lock" }}
+
   contract_cw1_whitelist:
     docker:
       - image: rust:1.44.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
+ "cw1-whitelist",
+ "cw20",
  "schemars",
  "serde",
  "snafu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,24 +2,24 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler32"
-version = "1.1.0"
+name = "adler"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "backtrace"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -43,9 +43,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.10.0-alpha2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131e629d2c7559551205c66db1e0afeab743e1874ee9209dbf8cf06a1e8d5732"
+checksum = "1592dd62fbf542dca476606d4768ae54c5febd586c5e246d147c3c90b2f4289c"
 dependencies = [
  "schemars",
  "serde_json",
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.10.0-alpha2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f848da5f60e976ab84bd3e22b1570754a71af31e2a0a0df506b65edc282723c3"
+checksum = "7934161da3638926acf9ac1ee92d0080993052df6dcd09fc5deb1d1ba6fbcb02"
 dependencies = [
  "base64",
  "schemars",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.10.0-alpha2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb517250ced8552c09380798949b8696be6fe77ee9f9c006491552ab88a8429"
+checksum = "24d8f927309936e47b2d593f602161bb5dbef4c717ee185b19618873b1370b93"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -154,9 +154,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "itoa"
@@ -166,17 +166,17 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
 dependencies = [
- "adler32",
+ "adler",
 ]
 
 [[package]]
@@ -187,9 +187,9 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw1-subkeys"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "schemars",
+ "serde",
+ "snafu",
+]
+
+[[package]]
 name = "cw1-whitelist"
 version = "0.1.0"
 dependencies = [

--- a/contracts/cw1-subkeys/.cargo/config
+++ b/contracts/cw1-subkeys/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib --features backtraces"
+integration-test = "test --test integration"
+schema = "run --example schema"

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -13,11 +13,11 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "0.9.2", features = ["iterator"] }
-cosmwasm-storage = { version = "0.9.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.10.0-alpha2", features = ["iterator"] }
+cosmwasm-storage = { version = "0.10.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.9.2" }
+cosmwasm-schema = { version = "0.10.0-alpha2" }

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cw1-subkeys"
+version = "0.1.0"
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+edition = "2018"
+description = "Implement subkeys for authorizing native tokens as a cw1 proxy contract"
+license = "AGPL-3.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+
+[dependencies]
+cosmwasm-std = { version = "0.9.2", features = ["iterator"] }
+cosmwasm-storage = { version = "0.9.2", features = ["iterator"] }
+schemars = "0.7"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+snafu = { version = "0.6.3" }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "0.9.2" }

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -15,6 +15,8 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = { version = "0.10.0-alpha2", features = ["iterator"] }
 cosmwasm-storage = { version = "0.10.0-alpha2", features = ["iterator"] }
+cw20 = { path = "../../packages/cw20", version = "0.1.0" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.1.0" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "0.10.0-alpha2", features = ["iterator"] }
-cosmwasm-storage = { version = "0.10.0-alpha2", features = ["iterator"] }
+cosmwasm-std = { version = "0.10.0", features = ["iterator"] }
+cosmwasm-storage = { version = "0.10.0", features = ["iterator"] }
 cw20 = { path = "../../packages/cw20", version = "0.1.0" }
 cw1-whitelist = { path = "../cw1-whitelist", version = "0.1.0" }
 schemars = "0.7"
@@ -22,4 +22,4 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.10.0-alpha2" }
+cosmwasm-schema = { version = "0.10.0" }

--- a/contracts/cw1-subkeys/NOTICE
+++ b/contracts/cw1-subkeys/NOTICE
@@ -1,0 +1,15 @@
+CosmWasm-Plus: A collection of production-quality CosmWasm contracts
+Copyright (C) 2020 Confio OÜ
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/contracts/cw1-subkeys/README.md
+++ b/contracts/cw1-subkeys/README.md
@@ -1,0 +1,84 @@
+# CW1 Subkeys
+
+This builds on `cw1-whitelist` to provide the first non-trivial solution.
+It still works like `cw1-whitelist` with a set of admins (typically 1)
+which have full control of the account. However, you can then grant
+a number of accounts allowances to send native tokens from this account.
+
+This was proposed in Summer 2019 for the Cosmos Hub and resembles the
+functionality of ERC20 (allowances and transfer from). 
+
+## Details
+
+Basically, any admin can add an allowance for a `(spender, denom)` pair 
+(similar to cw20 `IncreaseAllowance` / `DecreaseAllowance`). Any non-admin 
+account can try to execute a `CosmosMsg::Bank(BankMsg::Send{})` from this 
+contract and if they have the required allowances, there allowance will be 
+reduced and the send message relayed. If they don't have sufficient authorization, 
+or if they try to proxy any other message type, then the attempt will be rejected.
+
+### Messages
+
+This adds 2 messages beyond the `cw1` spec:
+
+```rust
+enum HandleMsg {
+    IncreaseAllowance {
+        spender: HumanAddr,
+        denom: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    DecreaseAllowance {
+        spender: HumanAddr,
+        denom: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    }
+}
+```
+
+### Queries
+
+It also adds one more query type:
+
+```rust
+enum QueryMsg {
+    Allowance {
+        spender: HumanAddr,
+    } 
+}
+
+pub struct AllowanceResponse {
+    pub allowance: Vec<Coin>,
+    pub expires: Expiration,
+}
+```
+
+## Running this contract
+
+You will need Rust 1.41+ with `wasm32-unknown-unknown` target installed.
+
+You can run unit tests on this via: 
+
+`cargo test`
+
+Once you are happy with the content, you can compile it to wasm via:
+
+```
+RUSTFLAGS='-C link-arg=-s' cargo wasm
+cp ../../target/wasm32-unknown-unknown/release/cw20_escrow.wasm .
+ls -l cw20_escrow.wasm
+sha256sum cw20_escrow.wasm
+```
+
+Or for a production-ready (compressed) build, run the following from the
+repository root (not currently working with this monorepo...)
+
+```
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="cosmwasm_plus_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.8.0 ./contracts/cw20-base
+mv contract.wasm cw20_escrow.wasm
+```

--- a/contracts/cw1-subkeys/README.md
+++ b/contracts/cw1-subkeys/README.md
@@ -57,7 +57,7 @@ pub struct AllowanceResponse {
 
 ## Running this contract
 
-You will need Rust 1.41+ with `wasm32-unknown-unknown` target installed.
+You will need Rust 1.41.1+ with `wasm32-unknown-unknown` target installed.
 
 You can run unit tests on this via: 
 
@@ -67,9 +67,9 @@ Once you are happy with the content, you can compile it to wasm via:
 
 ```
 RUSTFLAGS='-C link-arg=-s' cargo wasm
-cp ../../target/wasm32-unknown-unknown/release/cw20_escrow.wasm .
-ls -l cw20_escrow.wasm
-sha256sum cw20_escrow.wasm
+cp ../../target/wasm32-unknown-unknown/release/cw1_subkeys.wasm .
+ls -l cw1_subkeys.wasm
+sha256sum cw1_subkeys.wasm
 ```
 
 Or for a production-ready (compressed) build, run the following from the
@@ -79,6 +79,6 @@ repository root (not currently working with this monorepo...)
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="cosmwasm_plus_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.8.0 ./contracts/cw20-base
-mv contract.wasm cw20_escrow.wasm
+  cosmwasm/rust-optimizer:0.8.0 ./contracts/cw1-subkeys
+mv contract.wasm cw1_subkeys.wasm
 ```

--- a/contracts/cw1-subkeys/README.md
+++ b/contracts/cw1-subkeys/README.md
@@ -6,15 +6,15 @@ which have full control of the account. However, you can then grant
 a number of accounts allowances to send native tokens from this account.
 
 This was proposed in Summer 2019 for the Cosmos Hub and resembles the
-functionality of ERC20 (allowances and transfer from). 
+functionality of ERC20 (allowances and transfer from).
 
 ## Details
 
-Basically, any admin can add an allowance for a `(spender, denom)` pair 
-(similar to cw20 `IncreaseAllowance` / `DecreaseAllowance`). Any non-admin 
-account can try to execute a `CosmosMsg::Bank(BankMsg::Send{})` from this 
-contract and if they have the required allowances, there allowance will be 
-reduced and the send message relayed. If they don't have sufficient authorization, 
+Basically, any admin can add an allowance for a `(spender, denom)` pair
+(similar to cw20 `IncreaseAllowance` / `DecreaseAllowance`). Any non-admin
+account can try to execute a `CosmosMsg::Bank(BankMsg::Send{})` from this
+contract and if they have the required allowances, their allowance will be
+reduced and the send message relayed. If they don't have sufficient authorization,
 or if they try to proxy any other message type, then the attempt will be rejected.
 
 ### Messages
@@ -46,7 +46,7 @@ It also adds one more query type:
 enum QueryMsg {
     Allowance {
         spender: HumanAddr,
-    } 
+    }
 }
 
 pub struct AllowanceResponse {
@@ -57,9 +57,9 @@ pub struct AllowanceResponse {
 
 ## Running this contract
 
-You will need Rust 1.41.1+ with `wasm32-unknown-unknown` target installed.
+You will need Rust 1.44.1+ with `wasm32-unknown-unknown` target installed.
 
-You can run unit tests on this via: 
+You can run unit tests on this via:
 
 `cargo test`
 
@@ -79,6 +79,6 @@ repository root (not currently working with this monorepo...)
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="cosmwasm_plus_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.8.0 ./contracts/cw1-subkeys
+  cosmwasm/rust-optimizer:0.9.0 ./contracts/cw1-subkeys
 mv contract.wasm cw1_subkeys.wasm
 ```

--- a/contracts/cw1-subkeys/examples/schema.rs
+++ b/contracts/cw1-subkeys/examples/schema.rs
@@ -1,0 +1,18 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+use cw1_subkeys::msg::{ConfigResponse, HandleMsg, InitMsg, QueryMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InitMsg), &out_dir);
+    export_schema(&schema_for!(HandleMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(ConfigResponse), &out_dir);
+}

--- a/contracts/cw1-subkeys/examples/schema.rs
+++ b/contracts/cw1-subkeys/examples/schema.rs
@@ -3,7 +3,9 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use cw1_subkeys::msg::{ConfigResponse, HandleMsg, InitMsg, QueryMsg};
+use cw1_subkeys::msg::{HandleMsg, QueryMsg};
+use cw1_subkeys::state::Allowance;
+use cw1_whitelist::msg::{ConfigResponse, InitMsg};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -14,5 +16,6 @@ fn main() {
     export_schema(&schema_for!(InitMsg), &out_dir);
     export_schema(&schema_for!(HandleMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(Allowance), &out_dir);
     export_schema(&schema_for!(ConfigResponse), &out_dir);
 }

--- a/contracts/cw1-subkeys/schema/allowance.json
+++ b/contracts/cw1-subkeys/schema/allowance.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Allowance",
+  "type": "object",
+  "required": [
+    "balance",
+    "expires"
+  ],
+  "properties": {
+    "balance": {
+      "$ref": "#/definitions/Balance"
+    },
+    "expires": {
+      "$ref": "#/definitions/Expiration"
+    }
+  },
+  "definitions": {
+    "Balance": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Coin"
+      }
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "anyOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "object",
+              "required": [
+                "height"
+              ],
+              "properties": {
+                "height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "type": "object",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Never will never expire. Used to distinguish None from Some(Expiration::Never)",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          }
+        }
+      ]
+    },
+    "Uint128": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw1-subkeys/schema/config_response.json
+++ b/contracts/cw1-subkeys/schema/config_response.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ConfigResponse",
+  "type": "object",
+  "required": [
+    "admins",
+    "mutable"
+  ],
+  "properties": {
+    "admins": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/HumanAddr"
+      }
+    },
+    "mutable": {
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "HumanAddr": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw1-subkeys/schema/handle_msg_for__empty.json
+++ b/contracts/cw1-subkeys/schema/handle_msg_for__empty.json
@@ -59,6 +59,74 @@
           }
         }
       }
+    },
+    {
+      "description": "Add an allowance to a given subkey (subkey must not be admin)",
+      "type": "object",
+      "required": [
+        "increase_allowance"
+      ],
+      "properties": {
+        "increase_allowance": {
+          "type": "object",
+          "required": [
+            "amount",
+            "spender"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Coin"
+            },
+            "expires": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "spender": {
+              "$ref": "#/definitions/HumanAddr"
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Decreases an allowance for a given subkey (subkey must not be admin)",
+      "type": "object",
+      "required": [
+        "decrease_allowance"
+      ],
+      "properties": {
+        "decrease_allowance": {
+          "type": "object",
+          "required": [
+            "amount",
+            "spender"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Coin"
+            },
+            "expires": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "spender": {
+              "$ref": "#/definitions/HumanAddr"
+            }
+          }
+        }
+      }
     }
   ],
   "definitions": {
@@ -166,6 +234,66 @@
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object"
+    },
+    "Expiration": {
+      "anyOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "object",
+              "required": [
+                "height"
+              ],
+              "properties": {
+                "height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "type": "object",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Never will never expire. Used to distinguish None from Some(Expiration::Never)",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          }
+        }
+      ]
     },
     "HumanAddr": {
       "type": "string"

--- a/contracts/cw1-subkeys/schema/handle_msg_for__empty.json
+++ b/contracts/cw1-subkeys/schema/handle_msg_for__empty.json
@@ -1,0 +1,369 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "HandleMsg_for_Empty",
+  "anyOf": [
+    {
+      "description": "Execute requests the contract to re-dispatch all these messages with the contract's address as sender. Every implementation has it's own logic to determine in",
+      "type": "object",
+      "required": [
+        "execute"
+      ],
+      "properties": {
+        "execute": {
+          "type": "object",
+          "required": [
+            "msgs"
+          ],
+          "properties": {
+            "msgs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Freeze will make a mutable contract immutable, must be called by an admin",
+      "type": "object",
+      "required": [
+        "freeze"
+      ],
+      "properties": {
+        "freeze": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "UpdateAdmins will change the admin set of the contract, must be called by an existing admin, and only works if the contract is mutable",
+      "type": "object",
+      "required": [
+        "update_admins"
+      ],
+      "properties": {
+        "update_admins": {
+          "type": "object",
+          "required": [
+            "admins"
+          ],
+          "properties": {
+            "admins": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HumanAddr"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "BankMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "send"
+          ],
+          "properties": {
+            "send": {
+              "type": "object",
+              "required": [
+                "amount",
+                "from_address",
+                "to_address"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                },
+                "from_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "to_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "CosmosMsg_for_Empty": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "bank"
+          ],
+          "properties": {
+            "bank": {
+              "$ref": "#/definitions/BankMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "$ref": "#/definitions/Empty"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "staking"
+          ],
+          "properties": {
+            "staking": {
+              "$ref": "#/definitions/StakingMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "wasm"
+          ],
+          "properties": {
+            "wasm": {
+              "$ref": "#/definitions/WasmMsg"
+            }
+          }
+        }
+      ]
+    },
+    "Empty": {
+      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "type": "object"
+    },
+    "HumanAddr": {
+      "type": "string"
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Uint128": {
+      "type": "string"
+    },
+    "WasmMsg": {
+      "anyOf": [
+        {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "type": "object",
+          "required": [
+            "execute"
+          ],
+          "properties": {
+            "execute": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "send"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "type": "object",
+          "required": [
+            "instantiate"
+          ],
+          "properties": {
+            "instantiate": {
+              "type": "object",
+              "required": [
+                "code_id",
+                "msg",
+                "send"
+              ],
+              "properties": {
+                "code_id": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "label": {
+                  "description": "optional human-readbale label for the contract",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "msg": {
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contracts/cw1-subkeys/schema/init_msg.json
+++ b/contracts/cw1-subkeys/schema/init_msg.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InitMsg",
+  "type": "object",
+  "required": [
+    "admins",
+    "mutable"
+  ],
+  "properties": {
+    "admins": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/HumanAddr"
+      }
+    },
+    "mutable": {
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "HumanAddr": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw1-subkeys/schema/query_msg.json
+++ b/contracts/cw1-subkeys/schema/query_msg.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "anyOf": [
+    {
+      "description": "Shows all admins and whether or not it is mutable",
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object"
+        }
+      }
+    }
+  ]
+}

--- a/contracts/cw1-subkeys/schema/query_msg.json
+++ b/contracts/cw1-subkeys/schema/query_msg.json
@@ -3,7 +3,7 @@
   "title": "QueryMsg",
   "anyOf": [
     {
-      "description": "Shows all admins and whether or not it is mutable",
+      "description": "Shows all admins and whether or not it is mutable Returns cw1-whitelist::ConfigResponse",
       "type": "object",
       "required": [
         "config"
@@ -13,6 +13,31 @@
           "type": "object"
         }
       }
+    },
+    {
+      "description": "Get the current allowance for the given subkey (how much it can spend) Returns crate::state::Allowance",
+      "type": "object",
+      "required": [
+        "allowance"
+      ],
+      "properties": {
+        "allowance": {
+          "type": "object",
+          "required": [
+            "spender"
+          ],
+          "properties": {
+            "spender": {
+              "$ref": "#/definitions/HumanAddr"
+            }
+          }
+        }
+      }
     }
-  ]
+  ],
+  "definitions": {
+    "HumanAddr": {
+      "type": "string"
+    }
+  }
 }

--- a/contracts/cw1-subkeys/src/balance.rs
+++ b/contracts/cw1-subkeys/src/balance.rs
@@ -222,9 +222,9 @@ mod test {
         let no_btc = (balance.clone() - coin(555, "BTC")).unwrap();
         assert_eq!(no_btc, Balance(vec![coin(12345, "ETH")]));
 
-        // subtract more than we have
+        // subtract more than we have is tolerated
         let underflow = balance.clone() - coin(666, "BTC");
-        assert!(underflow.is_err());
+        assert!(underflow.is_ok());
 
         // subtract non-existent denom
         let missing = balance.clone() - coin(1, "ATOM");

--- a/contracts/cw1-subkeys/src/balance.rs
+++ b/contracts/cw1-subkeys/src/balance.rs
@@ -110,17 +110,29 @@ impl ops::Add<Balance> for Balance {
     }
 }
 
+impl ops::SubAssign<Coin> for Balance {
+    fn sub_assign(&mut self, other: Coin) {
+        // Warning: fails silently if no tokens
+        if let Some((i, c)) = self.find(&other.denom) {
+            if c.amount <= other.amount {
+                self.0.remove(i);
+            } else {
+                self.0[i].amount = (c.amount - other.amount).unwrap();
+            }
+        }
+    }
+}
+
 impl ops::Sub<Coin> for Balance {
     type Output = StdResult<Self>;
 
     fn sub(mut self, other: Coin) -> StdResult<Self> {
         match self.find(&other.denom) {
             Some((i, c)) => {
-                let remainder = (c.amount - other.amount)?;
-                if remainder.u128() == 0 {
+                if c.amount <= other.amount {
                     self.0.remove(i);
                 } else {
-                    self.0[i].amount = remainder;
+                    self.0[i].amount = (c.amount - other.amount).unwrap();
                 }
             }
             // error if no tokens

--- a/contracts/cw1-subkeys/src/balance.rs
+++ b/contracts/cw1-subkeys/src/balance.rs
@@ -129,8 +129,7 @@ impl ops::Sub<Coin> for Balance {
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm_std::{from_slice, to_vec};
-    use std::convert::TryInto;
+    use cosmwasm_std::coin;
 
     #[test]
     fn balance_has_works() {

--- a/contracts/cw1-subkeys/src/balance.rs
+++ b/contracts/cw1-subkeys/src/balance.rs
@@ -1,16 +1,15 @@
 use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::convert::TryFrom;
-use std::{fmt, ops};
+use serde::{Deserialize, Serialize};
+use std::ops;
 
-use cosmwasm_std::{underflow, StdError, Coin};
+use cosmwasm_std::{Coin, StdError, StdResult};
 
-// Wallet wraps Vec<Coin> and provides some nice helpers. It mutates the Vec and can be
+// Balance wraps Vec<Coin> and provides some nice helpers. It mutates the Vec and can be
 // unwrapped when done.
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
-pub struct Wallet(pub Vec<Coin>);
+pub struct Balance(pub Vec<Coin>);
 
-impl Wallet {
+impl Balance {
     pub fn into_vec(self) -> Vec<Coin> {
         self.0
     }
@@ -66,7 +65,7 @@ impl Wallet {
     }
 }
 
-impl ops::AddAssign<Coin> for Wallet {
+impl ops::AddAssign<Coin> for Balance {
     fn add_assign(&mut self, other: Coin) {
         match self.find(&other.denom) {
             Some((i, c)) => {
@@ -81,7 +80,7 @@ impl ops::AddAssign<Coin> for Wallet {
     }
 }
 
-impl ops::Add<Coin> for Wallet {
+impl ops::Add<Coin> for Balance {
     type Output = Self;
 
     fn add(mut self, other: Coin) -> Self {
@@ -90,24 +89,24 @@ impl ops::Add<Coin> for Wallet {
     }
 }
 
-impl ops::AddAssign<Wallet> for Wallet {
-    fn add_assign(&mut self, other: Wallet) {
+impl ops::AddAssign<Balance> for Balance {
+    fn add_assign(&mut self, other: Balance) {
         for coin in other.0.into_iter() {
             self.add_assign(coin);
         }
     }
 }
 
-impl ops::Add<Wallet> for Wallet {
+impl ops::Add<Balance> for Balance {
     type Output = Self;
 
-    fn add(mut self, other: Wallet) -> Self {
+    fn add(mut self, other: Balance) -> Self {
         self += other;
         self
     }
 }
 
-impl ops::Sub<Coin> for Wallet {
+impl ops::Sub<Coin> for Balance {
     type Output = StdResult<Self>;
 
     fn sub(mut self, other: Coin) -> StdResult<Self> {
@@ -121,7 +120,7 @@ impl ops::Sub<Coin> for Wallet {
                 }
             }
             // error if no tokens
-            None => return StdError::underflow(0, other.amount.u128()),
+            None => return Err(StdError::underflow(0, other.amount.u128())),
         };
         Ok(self)
     }
@@ -134,33 +133,36 @@ mod test {
     use std::convert::TryInto;
 
     #[test]
-    fn wallet_has_works() {
-        let wallet = Wallet(vec![coin(555, "BTC"), coin(12345, "ETH")]);
+    fn balance_has_works() {
+        let balance = Balance(vec![coin(555, "BTC"), coin(12345, "ETH")]);
 
         // less than same type
-        assert!(wallet.has(&coin(777, "ETH")));
+        assert!(balance.has(&coin(777, "ETH")));
         // equal to same type
-        assert!(wallet.has(&coin(555, "BTC")));
+        assert!(balance.has(&coin(555, "BTC")));
 
         // too high
-        assert!(!wallet.has(&coin(12346, "ETH")));
+        assert!(!balance.has(&coin(12346, "ETH")));
         // wrong type
-        assert!(!wallet.has(&coin(456, "ETC")));
+        assert!(!balance.has(&coin(456, "ETC")));
     }
 
     #[test]
-    fn wallet_add_works() {
-        let wallet = Wallet(vec![coin(555, "BTC"), coin(12345, "ETH")]);
+    fn balance_add_works() {
+        let balance = Balance(vec![coin(555, "BTC"), coin(12345, "ETH")]);
 
         // add an existing coin
-        let more_eth = wallet.clone() + coin(54321, "ETH");
-        assert_eq!(more_eth, Wallet(vec![coin(555, "BTC"), coin(66666, "ETH")]));
+        let more_eth = balance.clone() + coin(54321, "ETH");
+        assert_eq!(
+            more_eth,
+            Balance(vec![coin(555, "BTC"), coin(66666, "ETH")])
+        );
 
         // add an new coin
-        let add_atom = wallet.clone() + coin(777, "ATOM");
+        let add_atom = balance.clone() + coin(777, "ATOM");
         assert_eq!(
             add_atom,
-            Wallet(vec![
+            Balance(vec![
                 coin(777, "ATOM"),
                 coin(555, "BTC"),
                 coin(12345, "ETH"),
@@ -169,60 +171,66 @@ mod test {
     }
 
     #[test]
-    fn wallet_in_place_addition() {
-        let mut wallet = Wallet(vec![coin(555, "BTC")]);
-        wallet += coin(777, "ATOM");
-        assert_eq!(&wallet, &Wallet(vec![coin(777, "ATOM"), coin(555, "BTC")]));
-
-        wallet += Wallet(vec![coin(666, "ETH"), coin(123, "ATOM")]);
+    fn balance_in_place_addition() {
+        let mut balance = Balance(vec![coin(555, "BTC")]);
+        balance += coin(777, "ATOM");
         assert_eq!(
-            &wallet,
-            &Wallet(vec![coin(900, "ATOM"), coin(555, "BTC"), coin(666, "ETH")])
+            &balance,
+            &Balance(vec![coin(777, "ATOM"), coin(555, "BTC")])
         );
 
-        let foo = wallet + Wallet(vec![coin(234, "BTC")]);
+        balance += Balance(vec![coin(666, "ETH"), coin(123, "ATOM")]);
+        assert_eq!(
+            &balance,
+            &Balance(vec![coin(900, "ATOM"), coin(555, "BTC"), coin(666, "ETH")])
+        );
+
+        let foo = balance + Balance(vec![coin(234, "BTC")]);
         assert_eq!(
             &foo,
-            &Wallet(vec![coin(900, "ATOM"), coin(789, "BTC"), coin(666, "ETH")])
+            &Balance(vec![coin(900, "ATOM"), coin(789, "BTC"), coin(666, "ETH")])
         );
     }
 
     #[test]
-    fn wallet_subtract_works() {
-        let wallet = Wallet(vec![coin(555, "BTC"), coin(12345, "ETH")]);
+    fn balance_subtract_works() {
+        let balance = Balance(vec![coin(555, "BTC"), coin(12345, "ETH")]);
 
         // subtract less than we have
-        let less_eth = (wallet.clone() - coin(2345, "ETH")).unwrap();
-        assert_eq!(less_eth, Wallet(vec![coin(555, "BTC"), coin(10000, "ETH")]));
+        let less_eth = (balance.clone() - coin(2345, "ETH")).unwrap();
+        assert_eq!(
+            less_eth,
+            Balance(vec![coin(555, "BTC"), coin(10000, "ETH")])
+        );
 
         // subtract all of one coin (and remove with 0 amount)
-        let no_btc = (wallet.clone() - coin(555, "BTC")).unwrap();
-        assert_eq!(no_btc, Wallet(vec![coin(12345, "ETH")]));
+        let no_btc = (balance.clone() - coin(555, "BTC")).unwrap();
+        assert_eq!(no_btc, Balance(vec![coin(12345, "ETH")]));
 
         // subtract more than we have
-        let underflow = wallet.clone() - coin(666, "BTC");
+        let underflow = balance.clone() - coin(666, "BTC");
         assert!(underflow.is_err());
 
         // subtract non-existent denom
-        let missing = wallet.clone() - coin(1, "ATOM");
+        let missing = balance.clone() - coin(1, "ATOM");
         assert!(missing.is_err());
     }
 
     #[test]
-    fn normalize_wallet() {
+    fn normalize_balance() {
         // remove 0 value items and sort
-        let mut wallet = Wallet(vec![coin(123, "ETH"), coin(0, "BTC"), coin(8990, "ATOM")]);
-        wallet.normalize();
-        assert_eq!(wallet, Wallet(vec![coin(8990, "ATOM"), coin(123, "ETH")]));
+        let mut balance = Balance(vec![coin(123, "ETH"), coin(0, "BTC"), coin(8990, "ATOM")]);
+        balance.normalize();
+        assert_eq!(balance, Balance(vec![coin(8990, "ATOM"), coin(123, "ETH")]));
 
         // merge duplicate entries of same denom
-        let mut wallet = Wallet(vec![
+        let mut balance = Balance(vec![
             coin(123, "ETH"),
             coin(789, "BTC"),
             coin(321, "ETH"),
             coin(11, "BTC"),
         ]);
-        wallet.normalize();
-        assert_eq!(wallet, Wallet(vec![coin(800, "BTC"), coin(444, "ETH")]));
+        balance.normalize();
+        assert_eq!(balance, Balance(vec![coin(800, "BTC"), coin(444, "ETH")]));
     }
 }

--- a/contracts/cw1-subkeys/src/balance.rs
+++ b/contracts/cw1-subkeys/src/balance.rs
@@ -110,29 +110,17 @@ impl ops::Add<Balance> for Balance {
     }
 }
 
-impl ops::SubAssign<Coin> for Balance {
-    fn sub_assign(&mut self, other: Coin) {
-        // Warning: fails silently if no tokens
-        if let Some((i, c)) = self.find(&other.denom) {
-            if c.amount <= other.amount {
-                self.0.remove(i);
-            } else {
-                self.0[i].amount = (c.amount - other.amount).unwrap();
-            }
-        }
-    }
-}
-
 impl ops::Sub<Coin> for Balance {
     type Output = StdResult<Self>;
 
     fn sub(mut self, other: Coin) -> StdResult<Self> {
         match self.find(&other.denom) {
             Some((i, c)) => {
-                if c.amount <= other.amount {
+                let remainder = (c.amount - other.amount)?;
+                if remainder.u128() == 0 {
                     self.0.remove(i);
                 } else {
-                    self.0[i].amount = (c.amount - other.amount).unwrap();
+                    self.0[i].amount = remainder;
                 }
             }
             // error if no tokens

--- a/contracts/cw1-subkeys/src/balance.rs
+++ b/contracts/cw1-subkeys/src/balance.rs
@@ -210,9 +210,9 @@ mod test {
         let no_btc = (balance.clone() - coin(555, "BTC")).unwrap();
         assert_eq!(no_btc, Balance(vec![coin(12345, "ETH")]));
 
-        // subtract more than we have is tolerated
+        // subtract more than we have
         let underflow = balance.clone() - coin(666, "BTC");
-        assert!(underflow.is_ok());
+        assert!(underflow.is_err());
 
         // subtract non-existent denom
         let missing = balance.clone() - coin(1, "ATOM");

--- a/contracts/cw1-subkeys/src/balance.rs
+++ b/contracts/cw1-subkeys/src/balance.rs
@@ -63,6 +63,10 @@ impl Balance {
     fn insert_pos(&self, denom: &str) -> Option<usize> {
         self.0.iter().position(|c| c.denom.as_str() >= denom)
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl ops::AddAssign<Coin> for Balance {

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -14,7 +14,7 @@ use cw20::Expiration;
 
 use crate::msg::{HandleMsg, QueryMsg};
 use crate::state::{allowances, allowances_read, Allowance};
-use std::ops::{AddAssign, Sub};
+use std::ops::AddAssign;
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
@@ -145,7 +145,7 @@ where
         if let Some(exp) = expires {
             allowance.expires = exp;
         }
-        allowance.balance = allowance.balance.sub(amount.clone())?; // Fails if no tokens
+        allowance.balance = allowance.balance.sub_saturating(amount.clone())?; // Fails if no tokens
         Ok(allowance)
     })?;
     if allowance.balance.is_empty() {

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -170,7 +170,7 @@ where
         if let Some(exp) = expires {
             allowance.expires = exp;
         }
-        allowance.balance = allowance.balance.sub_saturating(amount.clone())?; // Fails if no tokens
+        allowance.balance = allowance.balance.sub_saturating(amount.clone())?; // Tolerates underflows (amount bigger than balance), but fails if there are no tokens at all for the denom (report potential errors)
         Ok(allowance)
     })?;
     if allowance.balance.is_empty() {

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -68,7 +68,7 @@ where
         let mut allowances = allowances(&mut deps.storage);
         let allow = allowances.may_load(owner_raw.as_slice())?;
         let mut allowance =
-            allow.ok_or_else(|| StdError::generic_err("No allowance for this account"))?;
+            allow.ok_or_else(|| StdError::not_found("No allowance for this account"))?;
         for msg in &msgs {
             match msg {
                 CosmosMsg::Bank(BankMsg::Send {
@@ -76,8 +76,6 @@ where
                     to_address: _,
                     amount,
                 }) => {
-                    // FIXME?: Can from_address be different from env.message.sender? (guess so)
-                    // FIXME?: Can from_address and to_address be the same? (i.e. fancy sender)
                     // Decrease allowance
                     for coin in amount {
                         allowance.balance = allowance.balance.sub(coin.clone())?;
@@ -168,7 +166,7 @@ where
     let allowance = allowances(&mut deps.storage).update(spender_raw.as_slice(), |allow| {
         // Fail fast
         let mut allowance =
-            allow.ok_or_else(|| StdError::generic_err("No allowance for this account"))?;
+            allow.ok_or_else(|| StdError::not_found("No allowance for this account"))?;
         if let Some(exp) = expires {
             allowance.expires = exp;
         }

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -283,7 +283,7 @@ mod tests {
 
         let expires_height = Expiration::AtHeight { height: 5432 };
         let expires_never = Expiration::Never {};
-        let expires_time = Expiration::AtTime { time: 1234567890};
+        let expires_time = Expiration::AtTime { time: 1234567890 };
         // Initially set first spender allowance with height expiration, the second with no expiration
         let expirations = vec![expires_height.clone(), expires_never.clone()];
 
@@ -371,7 +371,6 @@ mod tests {
                 expires: expires_time,
             }
         );
-
     }
 
     #[test]

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use cosmwasm_std::{
     log, to_binary, Api, Binary, Coin, CosmosMsg, Empty, Env, Extern, HandleResponse, HumanAddr,
-    InitResponse, Querier, StdResult, Storage,
+    InitResponse, Querier, StdError, StdResult, Storage,
 };
 use cw1_whitelist::{
     contract::{handle_freeze, handle_update_admins, init as whitelist_init, query_config},
@@ -14,6 +14,7 @@ use cw20::Expiration;
 
 use crate::msg::{HandleMsg, QueryMsg};
 use crate::state::{allowances, allowances_read, Allowance};
+use std::ops::AddAssign;
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
@@ -82,14 +83,38 @@ pub fn handle_increase_allowance<S: Storage, A: Api, Q: Querier, T>(
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
-    // placeholder to remove warnings
-    let _ = (deps, env, spender, amount, expires);
+    let cfg = config_read(&deps.storage).load()?;
+    let spender_raw = &deps.api.canonical_address(&spender)?;
+    let owner_raw = &deps.api.canonical_address(&env.message.sender)?;
 
-    // TODO
-    // look at cw20_base::contract::IncreaseAllowance
-    // if nothing present, we set this, and expires=None => Expiration::Never
-    // if something present, we add to the balance. expires=None => leave expiration at previous state, expires=Some(x) => set expires to new value x
-    panic!("unimplemented")
+    if !cfg.is_admin(&owner_raw) {
+        return Err(StdError::unauthorized());
+    }
+    if spender_raw == owner_raw {
+        return Err(StdError::generic_err("Cannot set allowance to own account"));
+    }
+
+    allowances(&mut deps.storage).update(spender_raw.as_slice(), |allow| {
+        let mut allowance = allow.unwrap_or_default();
+        if let Some(exp) = expires {
+            allowance.expires = exp;
+        }
+        allowance.balance.add_assign(amount.clone());
+        Ok(allowance)
+    })?;
+
+    let res = HandleResponse {
+        messages: vec![],
+        log: vec![
+            log("action", "increase_allowance"),
+            log("owner", env.message.sender),
+            log("spender", spender),
+            log("denomination", amount.denom),
+            log("amount", amount.amount),
+        ],
+        data: None,
+    };
+    Ok(res)
 }
 
 pub fn handle_decrease_allowance<S: Storage, A: Api, Q: Querier, T>(

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -139,16 +139,12 @@ where
     }
 
     let allowance = allowances(&mut deps.storage).update(spender_raw.as_slice(), |allow| {
-        if allow.is_none() {
-            // Fail fast
-            return Err(StdError::generic_err("No allowance for this account"));
-        }
-        let mut allowance = allow.unwrap();
-
+        // Fail fast
+        let mut allowance =
+            allow.ok_or_else(|| StdError::generic_err("No allowance for this account"))?;
         if let Some(exp) = expires {
             allowance.expires = exp;
         }
-
         allowance.balance = allowance.balance.sub(amount.clone())?; // Fails if no tokens
         Ok(allowance)
     })?;

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -1,0 +1,259 @@
+use schemars::JsonSchema;
+use std::fmt;
+
+use cosmwasm_std::{
+    log, to_binary, Api, Binary, CanonicalAddr, CosmosMsg, Empty, Env, Extern, HandleResponse,
+    HumanAddr, InitResponse, Querier, StdError, StdResult, Storage,
+};
+
+use crate::msg::{ConfigResponse, HandleMsg, InitMsg, QueryMsg};
+use crate::state::{config, config_read, Config};
+
+pub fn init<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    _env: Env,
+    msg: InitMsg,
+) -> StdResult<InitResponse> {
+    let cfg = Config {
+        admins: map_canonical(&deps.api, &msg.admins)?,
+        mutable: msg.mutable,
+    };
+    config(&mut deps.storage).save(&cfg)?;
+    Ok(InitResponse::default())
+}
+
+fn map_canonical<A: Api>(api: &A, admins: &[HumanAddr]) -> StdResult<Vec<CanonicalAddr>> {
+    admins
+        .iter()
+        .map(|addr| api.canonical_address(addr))
+        .collect()
+}
+
+fn map_human<A: Api>(api: &A, admins: &[CanonicalAddr]) -> StdResult<Vec<HumanAddr>> {
+    admins.iter().map(|addr| api.human_address(addr)).collect()
+}
+
+pub fn handle<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+    // Note: implement this function with different type to add support for custom messages
+    // and then import the rest of this contract code.
+    msg: HandleMsg<Empty>,
+) -> StdResult<HandleResponse<Empty>> {
+    match msg {
+        HandleMsg::Execute { msgs } => handle_execute(deps, env, msgs),
+        HandleMsg::Freeze {} => handle_freeze(deps, env),
+        HandleMsg::UpdateAdmins { admins } => handle_update_admins(deps, env, admins),
+    }
+}
+
+pub fn handle_execute<S: Storage, A: Api, Q: Querier, T>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+    msgs: Vec<CosmosMsg<T>>,
+) -> StdResult<HandleResponse<T>>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    let cfg = config_read(&deps.storage).load()?;
+    if !cfg.is_admin(&env.message.sender) {
+        Err(StdError::unauthorized())
+    } else {
+        let mut res = HandleResponse::default();
+        res.messages = msgs;
+        res.log = vec![log("action", "execute")];
+        Ok(res)
+    }
+}
+
+pub fn handle_freeze<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+) -> StdResult<HandleResponse> {
+    let mut cfg = config_read(&deps.storage).load()?;
+    if !cfg.can_modify(&env.message.sender) {
+        Err(StdError::unauthorized())
+    } else {
+        cfg.mutable = false;
+        config(&mut deps.storage).save(&cfg)?;
+
+        let mut res = HandleResponse::default();
+        res.log = vec![log("action", "freeze")];
+        Ok(res)
+    }
+}
+
+pub fn handle_update_admins<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+    admins: Vec<HumanAddr>,
+) -> StdResult<HandleResponse> {
+    let mut cfg = config_read(&deps.storage).load()?;
+    if !cfg.can_modify(&env.message.sender) {
+        Err(StdError::unauthorized())
+    } else {
+        cfg.admins = map_canonical(&deps.api, &admins)?;
+        config(&mut deps.storage).save(&cfg)?;
+
+        let mut res = HandleResponse::default();
+        res.log = vec![log("action", "update_admins")];
+        Ok(res)
+    }
+}
+
+pub fn query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    msg: QueryMsg,
+) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+    }
+}
+
+fn query_config<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+) -> StdResult<ConfigResponse> {
+    let cfg = config_read(&deps.storage).load()?;
+    Ok(ConfigResponse {
+        admins: map_human(&deps.api, &cfg.admins)?,
+        mutable: cfg.mutable,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, MOCK_CONTRACT_ADDR};
+    use cosmwasm_std::{coins, BankMsg, StdError, WasmMsg};
+
+    const CANONICAL_LENGTH: usize = 20;
+
+    #[test]
+    fn init_and_modify_config() {
+        let mut deps = mock_dependencies(CANONICAL_LENGTH, &[]);
+
+        let alice = HumanAddr::from("alice");
+        let bob = HumanAddr::from("bob");
+        let carl = HumanAddr::from("carl");
+
+        let anyone = HumanAddr::from("anyone");
+
+        // init the contract
+        let init_msg = InitMsg {
+            admins: vec![alice.clone(), bob.clone(), carl.clone()],
+            mutable: true,
+        };
+        let env = mock_env(&deps.api, &anyone, &[]);
+        init(&mut deps, env, init_msg).unwrap();
+
+        // ensure expected config
+        let expected = ConfigResponse {
+            admins: vec![alice.clone(), bob.clone(), carl.clone()],
+            mutable: true,
+        };
+        assert_eq!(query_config(&deps).unwrap(), expected);
+
+        // anyone cannot modify the contract
+        let msg = HandleMsg::UpdateAdmins {
+            admins: vec![anyone.clone()],
+        };
+        let env = mock_env(&deps.api, &anyone, &[]);
+        let res = handle(&mut deps, env, msg);
+        match res.unwrap_err() {
+            StdError::Unauthorized { .. } => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // but alice can kick out carl
+        let msg = HandleMsg::UpdateAdmins {
+            admins: vec![alice.clone(), bob.clone()],
+        };
+        let env = mock_env(&deps.api, &alice, &[]);
+        handle(&mut deps, env, msg).unwrap();
+
+        // ensure expected config
+        let expected = ConfigResponse {
+            admins: vec![alice.clone(), bob.clone()],
+            mutable: true,
+        };
+        assert_eq!(query_config(&deps).unwrap(), expected);
+
+        // carl cannot freeze it
+        let env = mock_env(&deps.api, &carl, &[]);
+        let res = handle(&mut deps, env, HandleMsg::Freeze {});
+        match res.unwrap_err() {
+            StdError::Unauthorized { .. } => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // but bob can
+        let env = mock_env(&deps.api, &bob, &[]);
+        handle(&mut deps, env, HandleMsg::Freeze {}).unwrap();
+        let expected = ConfigResponse {
+            admins: vec![alice.clone(), bob.clone()],
+            mutable: false,
+        };
+        assert_eq!(query_config(&deps).unwrap(), expected);
+
+        // and now alice cannot change it again
+        let msg = HandleMsg::UpdateAdmins {
+            admins: vec![alice.clone()],
+        };
+        let env = mock_env(&deps.api, &alice, &[]);
+        let res = handle(&mut deps, env, msg);
+        match res.unwrap_err() {
+            StdError::Unauthorized { .. } => {}
+            e => panic!("unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    fn execute_messages_has_proper_permissions() {
+        let mut deps = mock_dependencies(CANONICAL_LENGTH, &[]);
+
+        let alice = HumanAddr::from("alice");
+        let bob = HumanAddr::from("bob");
+        let carl = HumanAddr::from("carl");
+
+        // init the contract
+        let init_msg = InitMsg {
+            admins: vec![alice.clone(), carl.clone()],
+            mutable: false,
+        };
+        let env = mock_env(&deps.api, &bob, &[]);
+        init(&mut deps, env, init_msg).unwrap();
+
+        let freeze: HandleMsg<Empty> = HandleMsg::Freeze {};
+        let msgs = vec![
+            BankMsg::Send {
+                from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
+                to_address: bob.clone(),
+                amount: coins(10000, "DAI"),
+            }
+            .into(),
+            WasmMsg::Execute {
+                contract_addr: HumanAddr::from("some contract"),
+                msg: to_binary(&freeze).unwrap(),
+                send: vec![],
+            }
+            .into(),
+        ];
+
+        // make some nice message
+        let handle_msg = HandleMsg::Execute { msgs: msgs.clone() };
+
+        // bob cannot execute them
+        let env = mock_env(&deps.api, &bob, &[]);
+        let res = handle(&mut deps, env, handle_msg.clone());
+        match res.unwrap_err() {
+            StdError::Unauthorized { .. } => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // but carl can
+        let env = mock_env(&deps.api, &carl, &[]);
+        let res = handle(&mut deps, env, handle_msg.clone()).unwrap();
+        assert_eq!(res.messages, msgs);
+        assert_eq!(res.log, vec![log("action", "execute")]);
+    }
+}

--- a/contracts/cw1-subkeys/src/lib.rs
+++ b/contracts/cw1-subkeys/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod contract;
+pub mod msg;
+pub mod state;
+
+#[cfg(target_arch = "wasm32")]
+cosmwasm_std::create_entry_points!(contract);

--- a/contracts/cw1-subkeys/src/lib.rs
+++ b/contracts/cw1-subkeys/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod balance;
 pub mod contract;
 pub mod msg;
 pub mod state;

--- a/contracts/cw1-subkeys/src/msg.rs
+++ b/contracts/cw1-subkeys/src/msg.rs
@@ -2,13 +2,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use cosmwasm_std::{CosmosMsg, Empty, HumanAddr};
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-pub struct InitMsg {
-    pub admins: Vec<HumanAddr>,
-    pub mutable: bool,
-}
+use cosmwasm_std::{Coin, CosmosMsg, Empty, HumanAddr};
+use cw20::Expiration;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -25,17 +20,33 @@ where
     /// UpdateAdmins will change the admin set of the contract, must be called by an existing admin,
     /// and only works if the contract is mutable
     UpdateAdmins { admins: Vec<HumanAddr> },
+
+    /// Add an allowance to a given subkey (subkey must not be admin)
+    IncreaseAllowance {
+        spender: HumanAddr,
+        amount: Coin,
+        expires: Option<Expiration>,
+    },
+    /// Decreases an allowance for a given subkey (subkey must not be admin)
+    DecreaseAllowance {
+        spender: HumanAddr,
+        amount: Coin,
+        expires: Option<Expiration>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     /// Shows all admins and whether or not it is mutable
+    /// Returns cw1-whitelist::ConfigResponse
     Config {},
+    /// Returns the current allowance for the given subkey (how much it can spend)
+    Allowance { spender: HumanAddr },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct ConfigResponse {
-    pub admins: Vec<HumanAddr>,
-    pub mutable: bool,
+pub struct AllowanceResponse {
+    pub allowance: Vec<Coin>,
+    pub expires: Expiration,
 }

--- a/contracts/cw1-subkeys/src/msg.rs
+++ b/contracts/cw1-subkeys/src/msg.rs
@@ -1,0 +1,41 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use cosmwasm_std::{CosmosMsg, Empty, HumanAddr};
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct InitMsg {
+    pub admins: Vec<HumanAddr>,
+    pub mutable: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HandleMsg<T = Empty>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    /// Execute requests the contract to re-dispatch all these messages with the
+    /// contract's address as sender. Every implementation has it's own logic to
+    /// determine in
+    Execute { msgs: Vec<CosmosMsg<T>> },
+    /// Freeze will make a mutable contract immutable, must be called by an admin
+    Freeze {},
+    /// UpdateAdmins will change the admin set of the contract, must be called by an existing admin,
+    /// and only works if the contract is mutable
+    UpdateAdmins { admins: Vec<HumanAddr> },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    /// Shows all admins and whether or not it is mutable
+    Config {},
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct ConfigResponse {
+    pub admins: Vec<HumanAddr>,
+    pub mutable: bool,
+}

--- a/contracts/cw1-subkeys/src/msg.rs
+++ b/contracts/cw1-subkeys/src/msg.rs
@@ -41,12 +41,7 @@ pub enum QueryMsg {
     /// Shows all admins and whether or not it is mutable
     /// Returns cw1-whitelist::ConfigResponse
     Config {},
-    /// Returns the current allowance for the given subkey (how much it can spend)
+    /// Get the current allowance for the given subkey (how much it can spend)
+    /// Returns crate::state::Allowance
     Allowance { spender: HumanAddr },
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct AllowanceResponse {
-    pub allowance: Vec<Coin>,
-    pub expires: Expiration,
 }

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -9,19 +9,19 @@ use crate::balance::Balance;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
 pub struct Allowance {
-    balance: Balance,
-    expires: Expiration,
+    pub balance: Balance,
+    pub expires: Expiration,
 }
 
 const PREFIX_ALLOWANCE: &[u8] = b"allowance";
 
 /// returns a bucket with all allowances (query by subkey)
-pub fn allowances<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, Allowance> {
+pub fn allowances<S: Storage>(storage: &mut S) -> Bucket<S, Allowance> {
     bucket(PREFIX_ALLOWANCE, storage)
 }
 
 /// returns a bucket with all allowances (query by subkey)
 /// (read-only version for queries)
-pub fn allowances_read<'a, S: ReadonlyStorage>(storage: &'a S) -> ReadonlyBucket<'a, S, Allowance> {
+pub fn allowances_read<S: ReadonlyStorage>(storage: &S) -> ReadonlyBucket<S, Allowance> {
     bucket_read(PREFIX_ALLOWANCE, storage)
 }

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -7,7 +7,7 @@ use cw20::Expiration;
 
 use crate::balance::Balance;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
 pub struct Allowance {
     balance: Balance,
     expires: Expiration,

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -1,0 +1,82 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{CanonicalAddr, ReadonlyStorage, Storage};
+use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+pub struct Config {
+    pub admins: Vec<CanonicalAddr>,
+    pub mutable: bool,
+}
+
+impl Config {
+    /// returns true if the address is a registered admin
+    pub fn is_admin(&self, addr: &CanonicalAddr) -> bool {
+        self.admins.iter().any(|a| a == addr)
+    }
+
+    /// returns true if the address is a registered admin and the config is mutable
+    pub fn can_modify(&self, addr: &CanonicalAddr) -> bool {
+        self.mutable && self.is_admin(addr)
+    }
+}
+
+pub const CONFIG_KEY: &[u8] = b"config";
+
+// config is all config information
+pub fn config<S: Storage>(storage: &mut S) -> Singleton<S, Config> {
+    singleton(storage, CONFIG_KEY)
+}
+
+pub fn config_read<S: ReadonlyStorage>(storage: &S) -> ReadonlySingleton<S, Config> {
+    singleton_read(storage, CONFIG_KEY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::MockApi;
+    use cosmwasm_std::{Api, HumanAddr};
+
+    #[test]
+    fn is_admin() {
+        let api = MockApi::new(20);
+        let admins: Vec<_> = vec!["bob", "paul", "john"]
+            .into_iter()
+            .map(|name| api.canonical_address(&HumanAddr::from(name)).unwrap())
+            .collect();
+        let config = Config {
+            admins: admins.clone(),
+            mutable: false,
+        };
+
+        assert!(config.is_admin(&admins[0]));
+        assert!(config.is_admin(&admins[2]));
+        let other = api.canonical_address(&HumanAddr::from("other")).unwrap();
+        assert!(!config.is_admin(&other));
+    }
+
+    #[test]
+    fn can_modify() {
+        let api = MockApi::new(20);
+        let alice = api.canonical_address(&HumanAddr::from("alice")).unwrap();
+        let bob = api.canonical_address(&HumanAddr::from("bob")).unwrap();
+
+        // admin can modify mutable contract
+        let config = Config {
+            admins: vec![bob.clone()],
+            mutable: true,
+        };
+        assert!(!config.can_modify(&alice));
+        assert!(config.can_modify(&bob));
+
+        // no one can modify an immutable contract
+        let config = Config {
+            admins: vec![alice.clone()],
+            mutable: false,
+        };
+        assert!(!config.can_modify(&alice));
+        assert!(!config.can_modify(&bob));
+    }
+}

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -1,82 +1,27 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{CanonicalAddr, ReadonlyStorage, Storage};
-use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton};
+use cosmwasm_std::{ReadonlyStorage, Storage};
+use cosmwasm_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
+use cw20::Expiration;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
-pub struct Config {
-    pub admins: Vec<CanonicalAddr>,
-    pub mutable: bool,
+use crate::balance::Balance;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Allowance {
+    balance: Balance,
+    expires: Expiration,
 }
 
-impl Config {
-    /// returns true if the address is a registered admin
-    pub fn is_admin(&self, addr: &CanonicalAddr) -> bool {
-        self.admins.iter().any(|a| a == addr)
-    }
+const PREFIX_ALLOWANCE: &[u8] = b"allowance";
 
-    /// returns true if the address is a registered admin and the config is mutable
-    pub fn can_modify(&self, addr: &CanonicalAddr) -> bool {
-        self.mutable && self.is_admin(addr)
-    }
+/// returns a bucket with all allowances (query by subkey)
+pub fn allowances<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, Allowance> {
+    bucket(PREFIX_ALLOWANCE, storage)
 }
 
-pub const CONFIG_KEY: &[u8] = b"config";
-
-// config is all config information
-pub fn config<S: Storage>(storage: &mut S) -> Singleton<S, Config> {
-    singleton(storage, CONFIG_KEY)
-}
-
-pub fn config_read<S: ReadonlyStorage>(storage: &S) -> ReadonlySingleton<S, Config> {
-    singleton_read(storage, CONFIG_KEY)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use cosmwasm_std::testing::MockApi;
-    use cosmwasm_std::{Api, HumanAddr};
-
-    #[test]
-    fn is_admin() {
-        let api = MockApi::new(20);
-        let admins: Vec<_> = vec!["bob", "paul", "john"]
-            .into_iter()
-            .map(|name| api.canonical_address(&HumanAddr::from(name)).unwrap())
-            .collect();
-        let config = Config {
-            admins: admins.clone(),
-            mutable: false,
-        };
-
-        assert!(config.is_admin(&admins[0]));
-        assert!(config.is_admin(&admins[2]));
-        let other = api.canonical_address(&HumanAddr::from("other")).unwrap();
-        assert!(!config.is_admin(&other));
-    }
-
-    #[test]
-    fn can_modify() {
-        let api = MockApi::new(20);
-        let alice = api.canonical_address(&HumanAddr::from("alice")).unwrap();
-        let bob = api.canonical_address(&HumanAddr::from("bob")).unwrap();
-
-        // admin can modify mutable contract
-        let config = Config {
-            admins: vec![bob.clone()],
-            mutable: true,
-        };
-        assert!(!config.can_modify(&alice));
-        assert!(config.can_modify(&bob));
-
-        // no one can modify an immutable contract
-        let config = Config {
-            admins: vec![alice.clone()],
-            mutable: false,
-        };
-        assert!(!config.can_modify(&alice));
-        assert!(!config.can_modify(&bob));
-    }
+/// returns a bucket with all allowances (query by subkey)
+/// (read-only version for queries)
+pub fn allowances_read<'a, S: ReadonlyStorage>(storage: &'a S) -> ReadonlyBucket<'a, S, Allowance> {
+    bucket_read(PREFIX_ALLOWANCE, storage)
 }

--- a/contracts/cw1-subkeys/src/wallet.rs
+++ b/contracts/cw1-subkeys/src/wallet.rs
@@ -1,0 +1,228 @@
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
+use std::convert::TryFrom;
+use std::{fmt, ops};
+
+use cosmwasm_std::{underflow, StdError, Coin};
+
+// Wallet wraps Vec<Coin> and provides some nice helpers. It mutates the Vec and can be
+// unwrapped when done.
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
+pub struct Wallet(pub Vec<Coin>);
+
+impl Wallet {
+    pub fn into_vec(self) -> Vec<Coin> {
+        self.0
+    }
+
+    /// returns true if the list of coins has at least the required amount
+    pub fn has(&self, required: &Coin) -> bool {
+        self.0
+            .iter()
+            .find(|c| c.denom == required.denom)
+            .map(|m| m.amount >= required.amount)
+            .unwrap_or(false)
+    }
+
+    /// normalize Wallet (sorted by denom, no 0 elements, no duplicate denoms)
+    pub fn normalize(&mut self) {
+        // drop 0's
+        self.0.retain(|c| c.amount.u128() != 0);
+        // sort
+        self.0.sort_unstable_by(|a, b| a.denom.cmp(&b.denom));
+
+        // find all i where (self[i-1].denom == self[i].denom).
+        let mut dups: Vec<usize> = self
+            .0
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| {
+                if i != 0 && c.denom == self.0[i - 1].denom {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        dups.reverse();
+
+        // we go through the dups in reverse order (to avoid shifting indexes of other ones)
+        for dup in dups {
+            let add = self.0[dup].amount;
+            self.0[dup - 1].amount += add;
+            self.0.remove(dup);
+        }
+    }
+
+    fn find(&self, denom: &str) -> Option<(usize, &Coin)> {
+        self.0.iter().enumerate().find(|(_i, c)| c.denom == denom)
+    }
+
+    /// insert_pos should only be called when denom is not in the Wallet.
+    /// it returns the position where denom should be inserted at (via splice).
+    /// It returns None if this should be appended
+    fn insert_pos(&self, denom: &str) -> Option<usize> {
+        self.0.iter().position(|c| c.denom.as_str() >= denom)
+    }
+}
+
+impl ops::AddAssign<Coin> for Wallet {
+    fn add_assign(&mut self, other: Coin) {
+        match self.find(&other.denom) {
+            Some((i, c)) => {
+                self.0[i].amount = c.amount + other.amount;
+            }
+            // place this in proper sorted order
+            None => match self.insert_pos(&other.denom) {
+                Some(idx) => self.0.insert(idx, other),
+                None => self.0.push(other),
+            },
+        };
+    }
+}
+
+impl ops::Add<Coin> for Wallet {
+    type Output = Self;
+
+    fn add(mut self, other: Coin) -> Self {
+        self += other;
+        self
+    }
+}
+
+impl ops::AddAssign<Wallet> for Wallet {
+    fn add_assign(&mut self, other: Wallet) {
+        for coin in other.0.into_iter() {
+            self.add_assign(coin);
+        }
+    }
+}
+
+impl ops::Add<Wallet> for Wallet {
+    type Output = Self;
+
+    fn add(mut self, other: Wallet) -> Self {
+        self += other;
+        self
+    }
+}
+
+impl ops::Sub<Coin> for Wallet {
+    type Output = StdResult<Self>;
+
+    fn sub(mut self, other: Coin) -> StdResult<Self> {
+        match self.find(&other.denom) {
+            Some((i, c)) => {
+                let remainder = (c.amount - other.amount)?;
+                if remainder.u128() == 0 {
+                    self.0.remove(i);
+                } else {
+                    self.0[i].amount = remainder;
+                }
+            }
+            // error if no tokens
+            None => return StdError::underflow(0, other.amount.u128()),
+        };
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm_std::{from_slice, to_vec};
+    use std::convert::TryInto;
+
+    #[test]
+    fn wallet_has_works() {
+        let wallet = Wallet(vec![coin(555, "BTC"), coin(12345, "ETH")]);
+
+        // less than same type
+        assert!(wallet.has(&coin(777, "ETH")));
+        // equal to same type
+        assert!(wallet.has(&coin(555, "BTC")));
+
+        // too high
+        assert!(!wallet.has(&coin(12346, "ETH")));
+        // wrong type
+        assert!(!wallet.has(&coin(456, "ETC")));
+    }
+
+    #[test]
+    fn wallet_add_works() {
+        let wallet = Wallet(vec![coin(555, "BTC"), coin(12345, "ETH")]);
+
+        // add an existing coin
+        let more_eth = wallet.clone() + coin(54321, "ETH");
+        assert_eq!(more_eth, Wallet(vec![coin(555, "BTC"), coin(66666, "ETH")]));
+
+        // add an new coin
+        let add_atom = wallet.clone() + coin(777, "ATOM");
+        assert_eq!(
+            add_atom,
+            Wallet(vec![
+                coin(777, "ATOM"),
+                coin(555, "BTC"),
+                coin(12345, "ETH"),
+            ])
+        );
+    }
+
+    #[test]
+    fn wallet_in_place_addition() {
+        let mut wallet = Wallet(vec![coin(555, "BTC")]);
+        wallet += coin(777, "ATOM");
+        assert_eq!(&wallet, &Wallet(vec![coin(777, "ATOM"), coin(555, "BTC")]));
+
+        wallet += Wallet(vec![coin(666, "ETH"), coin(123, "ATOM")]);
+        assert_eq!(
+            &wallet,
+            &Wallet(vec![coin(900, "ATOM"), coin(555, "BTC"), coin(666, "ETH")])
+        );
+
+        let foo = wallet + Wallet(vec![coin(234, "BTC")]);
+        assert_eq!(
+            &foo,
+            &Wallet(vec![coin(900, "ATOM"), coin(789, "BTC"), coin(666, "ETH")])
+        );
+    }
+
+    #[test]
+    fn wallet_subtract_works() {
+        let wallet = Wallet(vec![coin(555, "BTC"), coin(12345, "ETH")]);
+
+        // subtract less than we have
+        let less_eth = (wallet.clone() - coin(2345, "ETH")).unwrap();
+        assert_eq!(less_eth, Wallet(vec![coin(555, "BTC"), coin(10000, "ETH")]));
+
+        // subtract all of one coin (and remove with 0 amount)
+        let no_btc = (wallet.clone() - coin(555, "BTC")).unwrap();
+        assert_eq!(no_btc, Wallet(vec![coin(12345, "ETH")]));
+
+        // subtract more than we have
+        let underflow = wallet.clone() - coin(666, "BTC");
+        assert!(underflow.is_err());
+
+        // subtract non-existent denom
+        let missing = wallet.clone() - coin(1, "ATOM");
+        assert!(missing.is_err());
+    }
+
+    #[test]
+    fn normalize_wallet() {
+        // remove 0 value items and sort
+        let mut wallet = Wallet(vec![coin(123, "ETH"), coin(0, "BTC"), coin(8990, "ATOM")]);
+        wallet.normalize();
+        assert_eq!(wallet, Wallet(vec![coin(8990, "ATOM"), coin(123, "ETH")]));
+
+        // merge duplicate entries of same denom
+        let mut wallet = Wallet(vec![
+            coin(123, "ETH"),
+            coin(789, "BTC"),
+            coin(321, "ETH"),
+            coin(11, "BTC"),
+        ]);
+        wallet.normalize();
+        assert_eq!(wallet, Wallet(vec![coin(800, "BTC"), coin(444, "ETH")]));
+    }
+}

--- a/contracts/cw1-whitelist/src/contract.rs
+++ b/contracts/cw1-whitelist/src/contract.rs
@@ -110,7 +110,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     }
 }
 
-fn query_config<S: Storage, A: Api, Q: Querier>(
+pub fn query_config<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
 ) -> StdResult<ConfigResponse> {
     let cfg = config_read(&deps.storage).load()?;


### PR DESCRIPTION
This idea was thrown around Summer 2019.

Basically an account that can authorize arbitrary external accounts to spend some limited amount of tokens from it. And in theory perform other actions (like staking).

This implements subkey controls over the native `Bank::SendMsg` action as part of a cw1-proxy contract.
