### PR TITLE
Enable contracts to import contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: cargo unit-test --locked
       - run:
           name: Build Wasm
-          command: cargo wasm-debug --locked
+          command: cargo wasm --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -75,7 +75,7 @@ jobs:
           command: cargo unit-test --locked
       - run:
           name: Build Wasm
-          command: cargo wasm-debug --locked
+          command: cargo wasm --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -116,7 +116,7 @@ jobs:
           command: cargo unit-test --locked
       - run:
           name: Build Wasm
-          command: cargo wasm-debug --locked
+          command: cargo wasm --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -157,7 +157,7 @@ jobs:
           command: cargo unit-test --locked
       - run:
           name: Build Wasm
-          command: cargo wasm-debug --locked
+          command: cargo wasm --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -197,7 +197,7 @@ jobs:
           command: cargo build --locked
       - run:
           name: Build library for wasm target
-          command: cargo wasm-debug --locked
+          command: cargo wasm --locked
       - run:
           name: Run unit tests
           command: cargo test --locked
@@ -240,7 +240,7 @@ jobs:
           command: cargo build --locked
       - run:
           name: Build library for wasm target
-          command: cargo wasm-debug --locked
+          command: cargo wasm --locked
       - run:
           name: Run unit tests
           command: cargo test --locked

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all init/handle/query exports
+library = []
 
 [dependencies]
 cosmwasm-std = { version = "0.10.0", features = ["iterator"] }

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -16,7 +16,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 cosmwasm-std = { version = "0.10.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.10.0", features = ["iterator"] }
 cw20 = { path = "../../packages/cw20", version = "0.1.0" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.1.0" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.1.0", features = ["library"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }

--- a/contracts/cw1-subkeys/src/lib.rs
+++ b/contracts/cw1-subkeys/src/lib.rs
@@ -3,5 +3,5 @@ pub mod contract;
 pub mod msg;
 pub mod state;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "library")))]
 cosmwasm_std::create_entry_points!(contract);

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -11,9 +11,10 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all init/handle/query exports
+library = []
 
 [dependencies]
-#cw1 = { path = "../../packages/cw1", version = "0.1.0" }
 cosmwasm-std = { version = "0.10.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.10.0", features = ["iterator"] }
 schemars = "0.7"

--- a/contracts/cw1-whitelist/src/lib.rs
+++ b/contracts/cw1-whitelist/src/lib.rs
@@ -2,5 +2,5 @@ pub mod contract;
 pub mod msg;
 pub mod state;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "library")))]
 cosmwasm_std::create_entry_points!(contract);

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -10,17 +10,9 @@ license = "AGPL-3.0"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-#default = ["cranelift", "entrypoint"]
-default = ["entrypoint"]
-# entrypoint means to expose init, handle, query extern "C" functions
-# disable this (default-features = false) if importing code for use in another contract
-entrypoint = []
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-#backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
-#cranelift = ["cosmwasm-vm/default-cranelift"]
-#singlepass = ["cosmwasm-vm/default-singlepass"]
+# use library feature to disable all init/handle/query exports
+library = []
 
 [dependencies]
 cw20 = { path = "../../packages/cw20", version = "0.1.0" }

--- a/contracts/cw20-base/src/lib.rs
+++ b/contracts/cw20-base/src/lib.rs
@@ -3,5 +3,5 @@ pub mod contract;
 pub mod msg;
 pub mod state;
 
-#[cfg(all(target_arch = "wasm32", feature = "entrypoint"))]
+#[cfg(all(target_arch = "wasm32", not(feature = "library")))]
 cosmwasm_std::create_entry_points!(contract);

--- a/contracts/cw20-escrow/Cargo.toml
+++ b/contracts/cw20-escrow/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all init/handle/query exports
+library = []
 
 [dependencies]
 cw20 = { path = "../../packages/cw20", version = "0.1.0" }

--- a/contracts/cw20-escrow/src/lib.rs
+++ b/contracts/cw20-escrow/src/lib.rs
@@ -2,5 +2,5 @@ pub mod contract;
 pub mod msg;
 pub mod state;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "library")))]
 cosmwasm_std::create_entry_points!(contract);


### PR DESCRIPTION
Closes #30 

- [x] Do release wasm build for contracts, to find link errors
- [x] Feature flag to conditionally compile the wasm imports, to allow use as libs