### PR TITLE
Cw2 migrate spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - contract_cw20_base
       - contract_cw20_escrow
       - package_cw1
+      - package_cw2
       - package_cw20
       - lint
 
@@ -176,49 +177,6 @@ jobs:
             - target
           key: cargocache-cw20-escrow-rust:1.44.1-{{ checksum "~/project/Cargo.lock" }}
 
-  package_cw20:
-    docker:
-      - image: rust:1.44.1
-    working_directory: ~/project/packages/cw20
-    steps:
-      - checkout:
-          path: ~/project
-      - run:
-          name: Version information
-          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
-      - restore_cache:
-          keys:
-            - cargocache-v2-cw20:1.44.1-{{ checksum "~/project/Cargo.lock" }}
-      - run:
-          name: Add wasm32 target
-          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
-      - run:
-          name: Build library for native target
-          command: cargo build --locked
-      - run:
-          name: Build library for wasm target
-          command: cargo wasm --locked
-      - run:
-          name: Run unit tests
-          command: cargo test --locked
-      - run:
-          name: Build and run schema generator
-          command: cargo schema --locked
-      - run:
-          name: Ensure schemas are up-to-date
-          command: |
-            CHANGES_IN_REPO=$(git status --porcelain)
-            if [[ -n "$CHANGES_IN_REPO" ]]; then
-              echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
-              git status && git --no-pager diff
-              exit 1
-            fi
-      - save_cache:
-          paths:
-            - /usr/local/cargo/registry
-            - target
-          key: cargocache-v2-cw20:1.44.1-{{ checksum "~/project/Cargo.lock" }}
-
   package_cw1:
     docker:
       - image: rust:1.44.1
@@ -261,6 +219,81 @@ jobs:
             - /usr/local/cargo/registry
             - target
           key: cargocache-v2-cw1:1.44.1-{{ checksum "~/project/Cargo.lock" }}
+
+  package_cw2:
+    docker:
+      - image: rust:1.44.1
+    working_directory: ~/project/packages/cw2
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - cargocache-v2-cw2:1.44.1-{{ checksum "~/project/Cargo.lock" }}
+      - run:
+          name: Add wasm32 target
+          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
+      - run:
+          name: Build library for native target
+          command: cargo build --locked
+      - run:
+          name: Build library for wasm target
+          command: cargo wasm --locked
+      - run:
+          name: Run unit tests
+          command: cargo test --locked
+      # note: there are no schemas to generate
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target
+          key: cargocache-v2-cw2:1.44.1-{{ checksum "~/project/Cargo.lock" }}
+
+  package_cw20:
+    docker:
+      - image: rust:1.44.1
+    working_directory: ~/project/packages/cw20
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - cargocache-v2-cw20:1.44.1-{{ checksum "~/project/Cargo.lock" }}
+      - run:
+          name: Add wasm32 target
+          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
+      - run:
+          name: Build library for native target
+          command: cargo build --locked
+      - run:
+          name: Build library for wasm target
+          command: cargo wasm --locked
+      - run:
+          name: Run unit tests
+          command: cargo test --locked
+      - run:
+          name: Build and run schema generator
+          command: cargo schema --locked
+      - run:
+          name: Ensure schemas are up-to-date
+          command: |
+            CHANGES_IN_REPO=$(git status --porcelain)
+            if [[ -n "$CHANGES_IN_REPO" ]]; then
+              echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+              git status && git --no-pager diff
+              exit 1
+            fi
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target
+          key: cargocache-v2-cw20:1.44.1-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw2"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw20"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,8 +114,8 @@ dependencies = [
 name = "cw2"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema",
  "cosmwasm-std",
+ "cosmwasm-storage",
  "schemars",
  "serde",
 ]

--- a/packages/cw2/.cargo/config
+++ b/packages/cw2/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+schema = "run --example schema"

--- a/packages/cw2/.cargo/config
+++ b/packages/cw2/.cargo/config
@@ -1,4 +1,3 @@
 [alias]
 wasm = "build --release --target wasm32-unknown-unknown"
 wasm-debug = "build --target wasm32-unknown-unknown"
-schema = "run --example schema"

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -8,8 +8,6 @@ license = "AGPL-3.0"
 
 [dependencies]
 cosmwasm-std = { version = "0.10.0" }
+cosmwasm-storage = { version = "0.10.0" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-
-[dev-dependencies]
-cosmwasm-schema = { version = "0.10.0" }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-2 interface"
-license = "AGPL-3.0"
+license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = { version = "0.10.0" }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cw2"
+version = "0.1.0"
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+edition = "2018"
+description = "Definition and types for the CosmWasm-2 interface"
+license = "AGPL-3.0"
+
+[dependencies]
+cosmwasm-std = { version = "0.10.0" }
+schemars = "0.7"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "0.10.0" }

--- a/packages/cw2/NOTICE
+++ b/packages/cw2/NOTICE
@@ -1,0 +1,15 @@
+CosmWasm-Plus: A collection of production-quality CosmWasm contracts
+Copyright (C) 2020 Confio OÜ
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/packages/cw2/NOTICE
+++ b/packages/cw2/NOTICE
@@ -1,15 +1,14 @@
-CosmWasm-Plus: A collection of production-quality CosmWasm contracts
+CW2: A CosmWasm spec for migration info
 Copyright (C) 2020 Confio OÜ
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/cw2/README.md
+++ b/packages/cw2/README.md
@@ -24,12 +24,14 @@ paths.
 All CW2-compliant contracts must store the following data:
 
 * key: `\x00\x0dcontract_info` (length prefixed "contract_info" using Singleton pattern)
-* data: Json-serialized `ContractInfo`
+* data: Json-serialized `ContractVersion`
 
 ```rust
 pub struct ContractVersion {
-    /// contract is the crate name of the implementing contract, eg. `crate:cw20-base`
-    /// we will use other prefixes for other languages, and their standard global namespacing
+    /// contract is a globally unique identifier for the contract.
+    /// it should build off standard namespacing for whichever language it is in,
+    /// and prefix it with the registry we use. 
+    /// For rust we prefix with `crates.io:`, to give us eg. `crates.io:cw20-base`
     pub contract: String,
     /// version is any string that this implementation knows. It may be simple counter "1", "2".
     /// or semantic version on release tags "v0.6.2", or some custom feature flag list.
@@ -37,37 +39,14 @@ pub struct ContractVersion {
     /// migrate from the given contract (and is tied to it's implementation somehow)
     pub version: String,
 }
-
-pub struct ContractInfo {
-    versions: Vec<ContractVersion>,
-}
 ```
 
 Thus, an serialized example may looks like:
 
 ```json
 {
-  "versions": [{
-    "contract": "crate:cw20-base",
+    "contract": "crates.io:cw20-base",
     "version": "v0.1.0"
-  }]
-}
-```
-
-Note we explicitly allow multiple version for mix-ins. For example,
-`cw1-subkeys` imports the config/admin list bucket from `cw1-whitelist`
-as well as adding some more info to it. We may want to explicitly mention
-the source of the state to be migrated:
-
-```json
-{
-  "versions": [{
-    "contract": "crate:cw1-whitelist",
-    "version": "v0.1.0"
-  }, {
-    "contract": "crate:cw1-subkeys",
-    "version": "v0.1.0"
-  }]
 }
 ```
 

--- a/packages/cw2/README.md
+++ b/packages/cw2/README.md
@@ -1,0 +1,78 @@
+# CW2 Spec: Contract Info for Migration
+
+Most of the CW* specs are focused on the *public interfaces*
+of the contract. The APIs used for `HandleMsg` or `QueryMsg`.
+However, when we wish to migrate from contract A to contract B,
+contract B needs to be aware somehow of how the *state was encoded*.
+
+Generally we use Singletons and Buckets to store the state, but
+if I upgrade to a `cw20-with-bonding-curve` contract, it will only
+work properly if I am migrating from a `cw20-base` contract. But how
+can the new contract know what format the data was stored.
+
+This is where CW2 comes in. It specifies on special Singleton to
+be stored on disk by all contracts on `init`. When the `migrate`
+function is called, then the new contract can read that data and
+see if this is an expected contract we can migrate from. And also
+contain extra version information if we support multiple migrate
+paths.
+
+### Data structures
+
+**Required**
+
+All CW2-compliant contracts must store the following data:
+
+* key: `\x00\x0dcontract_info` (length prefixed "contract_info" using Singleton pattern)
+* data: Json-serialized `ContractInfo`
+
+```rust
+pub struct ContractVersion {
+    /// contract is the crate name of the implementing contract, eg. `crate:cw20-base`
+    /// we will use other prefixes for other languages, and their standard global namespacing
+    pub contract: String,
+    /// version is any string that this implementation knows. It may be simple counter "1", "2".
+    /// or semantic version on release tags "v0.6.2", or some custom feature flag list.
+    /// the only code that needs to understand the version parsing is code that knows how to
+    /// migrate from the given contract (and is tied to it's implementation somehow)
+    pub version: String,
+}
+
+pub struct ContractInfo {
+    versions: Vec<ContractVersion>,
+}
+```
+
+Thus, an serialized example may looks like:
+
+```json
+{
+  "versions": [{
+    "contract": "crate:cw20-base",
+    "version": "v0.1.0"
+  }]
+}
+```
+
+Note we explicitly allow multiple version for mix-ins. For example,
+`cw1-subkeys` imports the config/admin list bucket from `cw1-whitelist`
+as well as adding some more info to it. We may want to explicitly mention
+the source of the state to be migrated:
+
+```json
+{
+  "versions": [{
+    "contract": "crate:cw1-whitelist",
+    "version": "v0.1.0"
+  }, {
+    "contract": "crate:cw1-subkeys",
+    "version": "v0.1.0"
+  }]
+}
+```
+
+### Queries
+
+Since the state is well defined, we do not need to support any "smart queries".
+We do provide a helper to construct a "raw query" to read the ContractInfo
+of any CW2-compliant contract.

--- a/packages/cw2/src/lib.rs
+++ b/packages/cw2/src/lib.rs
@@ -1,0 +1,27 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct ContractVersion {
+    /// contract is the crate name of the implementing contract, eg. `crate:cw20-base`
+    /// we will use other prefixes for other languages, and their standard global namespacing
+    pub contract: String,
+    /// version is any string that this implementation knows. It may be simple counter "1", "2".
+    /// or semantic version on release tags "v0.6.2", or some custom feature flag list.
+    /// the only code that needs to understand the version parsing is code that knows how to
+    /// migrate from the given contract (and is tied to it's implementation somehow)
+    pub version: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct ContractInfo {
+    versions: Vec<ContractVersion>,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
Add a new spec for standardized migration data.

This is just a singleton each contract can store to allow future contracts to more easily migrate from this implementation.

Question: is the flexibility of multiple implementaition/versions good, or should we just store `ContractVersion` rather than the more complex `ContractInfo`?