### PR TITLE
Cw20-base migration

### DIFF
--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -12,7 +12,7 @@ use cw1_whitelist::{
     msg::InitMsg,
     state::admin_list_read,
 };
-use cw2::{set_contract_version, ContractVersion};
+use cw2::set_contract_version;
 
 use crate::msg::{AllAllowancesResponse, AllowanceInfo, HandleMsg, QueryMsg};
 use crate::state::{allowances, allowances_read, Allowance};
@@ -27,15 +27,9 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
     env: Env,
     msg: InitMsg,
 ) -> StdResult<InitResponse> {
-    let version = ContractVersion {
-        contract: CONTRACT_NAME.to_string(),
-        version: CONTRACT_VERSION.to_string(),
-    };
-    let result = whitelist_init(deps, env, msg);
-    if result.is_ok() {
-        set_contract_version(&mut deps.storage, &version)?;
-    };
-    result
+    let result = whitelist_init(deps, env, msg)?;
+    set_contract_version(&mut deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(result)
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(

--- a/contracts/cw1-whitelist/src/contract.rs
+++ b/contracts/cw1-whitelist/src/contract.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
     HumanAddr, InitResponse, Querier, StdError, StdResult, Storage,
 };
 use cw1::CanSendResponse;
-use cw2::{set_contract_version, ContractVersion};
+use cw2::set_contract_version;
 
 use crate::msg::{AdminListResponse, HandleMsg, InitMsg, QueryMsg};
 use crate::state::{admin_list, admin_list_read, AdminList};
@@ -20,11 +20,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
     _env: Env,
     msg: InitMsg,
 ) -> StdResult<InitResponse> {
-    let version = ContractVersion {
-        contract: CONTRACT_NAME.to_string(),
-        version: CONTRACT_VERSION.to_string(),
-    };
-    set_contract_version(&mut deps.storage, &version)?;
+    set_contract_version(&mut deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     let cfg = AdminList {
         admins: map_canonical(&deps.api, &msg.admins)?,
         mutable: msg.mutable,

--- a/contracts/cw20-base/examples/schema.rs
+++ b/contracts/cw20-base/examples/schema.rs
@@ -7,7 +7,7 @@ use cw20::{
     AllAccountsResponse, AllAllowancesResponse, AllowanceResponse, BalanceResponse,
     TokenInfoResponse,
 };
-use cw20_base::msg::{HandleMsg, InitMsg, QueryMsg};
+use cw20_base::msg::{HandleMsg, InitMsg, MigrateMsg, QueryMsg};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -18,6 +18,7 @@ fn main() {
     export_schema(&schema_for!(InitMsg), &out_dir);
     export_schema(&schema_for!(HandleMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(MigrateMsg), &out_dir);
     export_schema(&schema_for!(AllowanceResponse), &out_dir);
     export_schema(&schema_for!(BalanceResponse), &out_dir);
     export_schema(&schema_for!(TokenInfoResponse), &out_dir);

--- a/contracts/cw20-base/schema/migrate_msg.json
+++ b/contracts/cw20-base/schema/migrate_msg.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateMsg",
+  "description": "We currently take no arguments for migrations",
+  "type": "object"
+}

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -18,22 +18,12 @@ use crate::state::{balances, balances_read, token_info, token_info_read, MinterD
 const CONTRACT_NAME: &str = "crates.io:cw20-base";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn store_version<S: Storage>(storage: &mut S) -> StdResult<()> {
-    set_contract_version(
-        storage,
-        &ContractVersion {
-            contract: CONTRACT_NAME.to_string(),
-            version: CONTRACT_VERSION.to_string(),
-        },
-    )
-}
-
 pub fn init<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     _env: Env,
     msg: InitMsg,
 ) -> StdResult<InitResponse> {
-    store_version(&mut deps.storage)?;
+    set_contract_version(&mut deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     // check valid token info
     msg.validate()?;
     // create initial accounts
@@ -336,7 +326,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
     }
     if old_version.version.starts_with("0.1.") {
         migrate_v01_to_v02(&mut deps.storage)?;
-        store_version(&mut deps.storage)?;
+        set_contract_version(&mut deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
         return Ok(MigrateResponse::default());
     }
     Err(StdError::generic_err(format!(

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{
     log, to_binary, Api, Binary, Env, Extern, HandleResponse, HumanAddr, InitResponse,
     MigrateResponse, Querier, StdError, StdResult, Storage, Uint128,
 };
-use cw2::{get_contract_version, set_contract_version, ContractVersion};
+use cw2::{get_contract_version, set_contract_version};
 use cw20::{BalanceResponse, Cw20ReceiveMsg, MinterResponse, TokenInfoResponse};
 
 use crate::allowances::{

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -324,7 +324,9 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
             CONTRACT_NAME, old_version.contract
         )));
     }
-    if old_version.version.starts_with("0.1.") {
+    // note: v0.1.0 were not auto-generated and started with v0.
+    // more recent versions do not have the v prefix
+    if old_version.version.starts_with("v0.1.") {
         migrate_v01_to_v02(&mut deps.storage)?;
         set_contract_version(&mut deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
         return Ok(MigrateResponse::default());
@@ -337,9 +339,14 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env};
-    use cosmwasm_std::{coins, from_binary, CosmosMsg, StdError, WasmMsg};
+    use cosmwasm_std::{coins, from_binary, CosmosMsg, Order, StdError, WasmMsg};
+    use cw2::ContractVersion;
+
+    use super::*;
+    use crate::migrations::generate_v01_test_data;
+    use crate::state::allowances_read;
+    use cw20::{AllowanceResponse, Expiration};
 
     const CANONICAL_LENGTH: usize = 20;
 
@@ -808,5 +815,104 @@ mod tests {
         assert_eq!(get_balance(&deps, &addr1), remainder);
         assert_eq!(get_balance(&deps, &contract), transfer);
         assert_eq!(query_token_info(&deps).unwrap().total_supply, amount1);
+    }
+
+    #[test]
+    fn migrate_from_v01() {
+        let mut deps = mock_dependencies(20, &[]);
+
+        generate_v01_test_data(&mut deps.storage, &deps.api).unwrap();
+        // make sure this really is 0.1.0
+        assert_eq!(
+            get_contract_version(&deps.storage).unwrap(),
+            ContractVersion {
+                contract: CONTRACT_NAME.to_string(),
+                version: "v0.1.0".to_string(),
+            }
+        );
+
+        // run the migration
+        let env = mock_env(HumanAddr::from("admin"), &[]);
+        migrate(&mut deps, env, MigrateMsg {}).unwrap();
+
+        // make sure the version is updated
+        assert_eq!(
+            get_contract_version(&deps.storage).unwrap(),
+            ContractVersion {
+                contract: CONTRACT_NAME.to_string(),
+                version: CONTRACT_VERSION.to_string(),
+            }
+        );
+
+        // check all the data (against the spec in generate_v01_test_data)
+        let info = token_info_read(&deps.storage).load().unwrap();
+        assert_eq!(
+            info,
+            TokenInfo {
+                name: "Sample Coin".to_string(),
+                symbol: "SAMP".to_string(),
+                decimals: 2,
+                total_supply: Uint128(777777),
+                mint: None,
+            }
+        );
+
+        // 2 users
+        let user1 = deps
+            .api
+            .canonical_address(&HumanAddr::from("user1"))
+            .unwrap();
+        let user2 = deps
+            .api
+            .canonical_address(&HumanAddr::from("user2"))
+            .unwrap();
+
+        let bal = balances_read(&deps.storage);
+        assert_eq!(2, bal.range(None, None, Order::Descending).count());
+        assert_eq!(bal.load(user1.as_slice()).unwrap(), Uint128(123456));
+        assert_eq!(bal.load(user2.as_slice()).unwrap(), Uint128(654321));
+
+        let spender1 = deps
+            .api
+            .canonical_address(&HumanAddr::from("spender1"))
+            .unwrap();
+        let spender2 = deps
+            .api
+            .canonical_address(&HumanAddr::from("spender2"))
+            .unwrap();
+
+        let num_allows = allowances_read(&deps.storage, &user1)
+            .range(None, None, Order::Ascending)
+            .count();
+        assert_eq!(num_allows, 1);
+        let allow = allowances_read(&deps.storage, &user1)
+            .load(spender1.as_slice())
+            .unwrap();
+        let expect = AllowanceResponse {
+            allowance: Uint128(5000),
+            expires: Expiration::AtHeight(5000),
+        };
+        assert_eq!(allow, expect);
+
+        let num_allows = allowances_read(&deps.storage, &user2)
+            .range(None, None, Order::Ascending)
+            .count();
+        assert_eq!(num_allows, 2);
+        let allow = allowances_read(&deps.storage, &user2)
+            .load(spender1.as_slice())
+            .unwrap();
+        let expect = AllowanceResponse {
+            allowance: Uint128(15000),
+            expires: Expiration::AtTime(1598647517),
+        };
+        assert_eq!(allow, expect);
+        let allow = allowances_read(&deps.storage, &user2)
+            .load(spender2.as_slice())
+            .unwrap();
+        let expect = AllowanceResponse {
+            allowance: Uint128(77777),
+            expires: Expiration::Never {},
+        };
+        assert_eq!(allow, expect);
     }
 }

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -1,7 +1,4 @@
-use cosmwasm_std::{
-    log, to_binary, Api, Binary, Env, Extern, HandleResponse, HumanAddr, InitResponse, Querier,
-    StdError, StdResult, Storage, Uint128,
-};
+use cosmwasm_std::{log, to_binary, Api, Binary, Env, Extern, HandleResponse, HumanAddr, InitResponse, Querier, StdError, StdResult, Storage, Uint128, MigrateResponse};
 use cw2::{set_contract_version, ContractVersion};
 use cw20::{BalanceResponse, Cw20ReceiveMsg, MinterResponse, TokenInfoResponse};
 
@@ -10,7 +7,7 @@ use crate::allowances::{
     handle_transfer_from, query_allowance,
 };
 use crate::enumerable::{query_all_accounts, query_all_allowances};
-use crate::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
+use crate::msg::{HandleMsg, InitMsg, InitialBalance, MigrateMsg, QueryMsg};
 use crate::state::{balances, balances_read, token_info, token_info_read, MinterData, TokenInfo};
 
 // version info for migration info
@@ -313,6 +310,14 @@ pub fn query_minter<S: Storage, A: Api, Q: Querier>(
         None => None,
     };
     Ok(minter)
+}
+
+pub fn migrate<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+    _msg: MigrateMsg,
+) -> StdResult<MigrateResponse> {
+    Ok(MigrateResponse::default())
 }
 
 #[cfg(test)]

--- a/contracts/cw20-base/src/lib.rs
+++ b/contracts/cw20-base/src/lib.rs
@@ -4,5 +4,7 @@ pub mod enumerable;
 pub mod msg;
 pub mod state;
 
+mod migrations;
+
 #[cfg(all(target_arch = "wasm32", not(feature = "library")))]
-cosmwasm_std::create_entry_points!(contract);
+cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/contracts/cw20-base/src/migrations/README.md
+++ b/contracts/cw20-base/src/migrations/README.md
@@ -1,0 +1,4 @@
+# Migrations
+
+This includes older data types so we can migrate older contracts to
+newer versions of the codebase

--- a/contracts/cw20-base/src/migrations/mod.rs
+++ b/contracts/cw20-base/src/migrations/mod.rs
@@ -1,0 +1,3 @@
+mod v01;
+
+pub use v01::migrate_v01_to_v02;

--- a/contracts/cw20-base/src/migrations/mod.rs
+++ b/contracts/cw20-base/src/migrations/mod.rs
@@ -1,3 +1,4 @@
 mod v01;
 
 pub use v01::migrate_v01_to_v02;
+pub use v01::testing::generate_v01_test_data;

--- a/contracts/cw20-base/src/migrations/v01.rs
+++ b/contracts/cw20-base/src/migrations/v01.rs
@@ -1,0 +1,7 @@
+use cosmwasm_std::{StdResult, Storage};
+
+/// this takes a v0.1.x store and converts it to a v0.2.x format
+pub fn migrate_v01_to_v02<S: Storage>(storage: &mut S) -> StdResult<()> {
+    // TODO
+    Ok(())
+}

--- a/contracts/cw20-base/src/migrations/v01.rs
+++ b/contracts/cw20-base/src/migrations/v01.rs
@@ -115,7 +115,7 @@ pub mod testing {
         //  - Allowance: Spender1, 15000, AtTime(1598647517)
         //  - Allowance: Spender2, 77777, Never
 
-        set_contract_version(storage, "crates.io:cw20-base", "0.1.0")?;
+        set_contract_version(storage, "crates.io:cw20-base", "v0.1.0")?;
         crate::state::token_info(storage).save(&crate::state::TokenInfo {
             name: "Sample Coin".to_string(),
             symbol: "SAMP".to_string(),

--- a/contracts/cw20-base/src/migrations/v01.rs
+++ b/contracts/cw20-base/src/migrations/v01.rs
@@ -1,7 +1,93 @@
-use cosmwasm_std::{StdResult, Storage};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{Order, StdResult, Storage, Uint128};
+use cosmwasm_storage::Bucket;
+use cw20::{AllowanceResponse, Expiration};
 
 /// this takes a v0.1.x store and converts it to a v0.2.x format
 pub fn migrate_v01_to_v02<S: Storage>(storage: &mut S) -> StdResult<()> {
-    // TODO
+    // load all the data that needs to change
+    let to_migrate: StdResult<Vec<(Vec<u8>, AllowanceResponse)>> = old_allowances(storage)
+        .range(None, None, Order::Ascending)
+        .filter_map(|item| {
+            match item {
+                // pass though errors
+                Err(e) => Some(Err(e)),
+                // filter out if expiration is none
+                Ok((
+                    _,
+                    OldAllowanceResponse {
+                        expires: OldExpiration::Never {},
+                        ..
+                    },
+                )) => None,
+                // convert the rest
+                Ok((k, v)) => Some(Ok((k, v.into()))),
+            }
+        })
+        .collect();
+
+    // overwrite these ones with the new format
+    let mut updated = new_allowances(storage);
+    for (k, v) in to_migrate?.into_iter() {
+        updated.save(&k, &v)?;
+    }
+
     Ok(())
+}
+
+/// this read the allowances bucket in the old format
+fn old_allowances<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, OldAllowanceResponse> {
+    Bucket::new(PREFIX_ALLOWANCE, storage)
+}
+
+/// This allows us to write in the new format
+fn new_allowances<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, AllowanceResponse> {
+    Bucket::new(PREFIX_ALLOWANCE, storage)
+}
+
+const PREFIX_ALLOWANCE: &[u8] = b"allowance";
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+pub struct OldAllowanceResponse {
+    pub allowance: Uint128,
+    pub expires: OldExpiration,
+}
+
+/// Convert the OldAllowanceResponse format into the new one
+impl Into<AllowanceResponse> for OldAllowanceResponse {
+    fn into(self) -> AllowanceResponse {
+        AllowanceResponse {
+            allowance: self.allowance,
+            expires: self.expires.into(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum OldExpiration {
+    /// AtHeight will expire when `env.block.height` >= height
+    AtHeight { height: u64 },
+    /// AtTime will expire when `env.block.time` >= time
+    AtTime { time: u64 },
+    /// Never will never expire. Used to distinguish None from Some(Expiration::Never)
+    Never {},
+}
+
+impl Default for OldExpiration {
+    fn default() -> Self {
+        OldExpiration::Never {}
+    }
+}
+
+impl Into<Expiration> for OldExpiration {
+    fn into(self) -> Expiration {
+        match self {
+            OldExpiration::AtHeight { height } => Expiration::AtHeight(height),
+            OldExpiration::AtTime { time } => Expiration::AtTime(time),
+            OldExpiration::Never {} => Expiration::Never {},
+        }
+    }
 }

--- a/contracts/cw20-base/src/migrations/v01.rs
+++ b/contracts/cw20-base/src/migrations/v01.rs
@@ -91,3 +91,29 @@ impl Into<Expiration> for OldExpiration {
         }
     }
 }
+
+pub mod testing {
+    use super::*;
+    use cw2::{set_contract_version, ContractVersion};
+
+    /// This generates test data as if it came from v0.1.0
+    /// TODO: make this more robust - how to manage old state?
+    /// Maybe we add export and import functions for MockStorage to generate JSON test vectors?
+    /// Maybe we embed the entire v0.1 code here to generate state??
+    pub fn generate_v01_test_data<S: Storage>(storage: &mut S) -> StdResult<()> {
+        // TokenInfo:
+        // name: Sample Coin
+        // symbol: SAMP
+        // decimals: 2
+        // total_supply: 777777
+
+        // User1: Balance 123456
+        //  - Allowance: Spender1, 5000, AtHeight(5000)
+        // User2: Balance 654321
+        //  - Allowance: Spender1, 15000, AtTime(1598647517)
+        //  - Allowance: Spender2, 77777, Never
+
+        set_contract_version(storage, "crates.io:cw20-base", "0.1.0")?;
+        Ok(())
+    }
+}

--- a/contracts/cw20-base/src/migrations/v01.rs
+++ b/contracts/cw20-base/src/migrations/v01.rs
@@ -38,12 +38,12 @@ pub fn migrate_v01_to_v02<S: Storage>(storage: &mut S) -> StdResult<()> {
 }
 
 /// this read the allowances bucket in the old format
-fn old_allowances<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, OldAllowanceResponse> {
+fn old_allowances<S: Storage>(storage: &mut S) -> Bucket<S, OldAllowanceResponse> {
     Bucket::new(PREFIX_ALLOWANCE, storage)
 }
 
 /// This allows us to write in the new format
-fn new_allowances<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, AllowanceResponse> {
+fn new_allowances<S: Storage>(storage: &mut S) -> Bucket<S, AllowanceResponse> {
     Bucket::new(PREFIX_ALLOWANCE, storage)
 }
 

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -157,3 +157,7 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
 }
+
+/// We currently take no arguments for migrations
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrateMsg {}

--- a/contracts/cw20-escrow/src/contract.rs
+++ b/contracts/cw20-escrow/src/contract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{
     from_binary, log, to_binary, Api, BankMsg, Binary, Coin, CosmosMsg, Env, Extern,
     HandleResponse, HumanAddr, InitResponse, Querier, StdError, StdResult, Storage, WasmMsg,
 };
-use cw2::{set_contract_version, ContractVersion};
+use cw2::set_contract_version;
 use cw20::{Cw20HandleMsg, Cw20ReceiveMsg};
 
 use crate::msg::{
@@ -21,11 +21,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
     _env: Env,
     _msg: InitMsg,
 ) -> StdResult<InitResponse> {
-    let version = ContractVersion {
-        contract: CONTRACT_NAME.to_string(),
-        version: CONTRACT_VERSION.to_string(),
-    };
-    set_contract_version(&mut deps.storage, &version)?;
+    set_contract_version(&mut deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     // no setup
     Ok(InitResponse::default())
 }

--- a/contracts/cw20-staking/src/contract.rs
+++ b/contracts/cw20-staking/src/contract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{
     coin, log, to_binary, Api, BankMsg, Binary, Decimal, Env, Extern, HandleResponse, HumanAddr,
     InitResponse, Querier, StakingMsg, StdError, StdResult, Storage, Uint128, WasmMsg,
 };
-use cw2::{set_contract_version, ContractVersion};
+use cw2::set_contract_version;
 use cw20_base::allowances::{
     handle_burn_from, handle_decrease_allowance, handle_increase_allowance, handle_send_from,
     handle_transfer_from, query_allowance,
@@ -29,11 +29,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
     env: Env,
     msg: InitMsg,
 ) -> StdResult<InitResponse> {
-    let version = ContractVersion {
-        contract: CONTRACT_NAME.to_string(),
-        version: CONTRACT_VERSION.to_string(),
-    };
-    set_contract_version(&mut deps.storage, &version)?;
+    set_contract_version(&mut deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     // ensure the validator is registered
     let vals = deps.querier.query_validators()?;

--- a/packages/cw2/src/lib.rs
+++ b/packages/cw2/src/lib.rs
@@ -27,8 +27,15 @@ pub fn get_contract_version<S: ReadonlyStorage>(storage: &S) -> StdResult<Contra
 
 /// set_contract_version should be used in init to store the original version, and after a successful
 /// migrate to update it
-pub fn set_contract_version<S: Storage>(storage: &mut S, info: &ContractVersion) -> StdResult<()> {
-    Singleton::new(storage, PREFIX_INFO).save(info)
+pub fn set_contract_version<S: Storage, T: Into<String>, U: Into<String>>(
+    storage: &mut S,
+    name: T,
+    version: U,
+) -> StdResult<()> {
+    Singleton::new(storage, PREFIX_INFO).save(&ContractVersion {
+        contract: name.into(),
+        version: version.into(),
+    })
 }
 
 /// This will make a raw_query to another contract to determine the current version it

--- a/packages/cw2/src/lib.rs
+++ b/packages/cw2/src/lib.rs
@@ -67,12 +67,15 @@ mod tests {
         assert!(get_contract_version(&store).is_err());
 
         // set and get
-        let info = ContractVersion {
-            contract: "crate:cw20-base".to_string(),
-            version: "v0.1.0".to_string(),
-        };
-        set_contract_version(&mut store, &info).unwrap();
+        let contract_name = "crate:cw20-base";
+        let contract_version = "0.2.0";
+        set_contract_version(&mut store, contract_name, contract_version).unwrap();
+
         let loaded = get_contract_version(&store).unwrap();
-        assert_eq!(info, loaded);
+        let expected = ContractVersion {
+            contract: contract_name.to_string(),
+            version: contract_version.to_string(),
+        };
+        assert_eq!(expected, loaded);
     }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+# these are imported by other packages
+BASE_PACKAGES="cw0"
+ALL_PACKAGES="cw1 cw2 cw20 cw721"
+
+# these are imported by other contracts
+BASE_CONTRACTS="cw1-whitelist cw20-base"
+ALL_CONTRACTS="cw1-subkeys cw20-escrow cw20-staking"
+
+SLEEP_TIME=30
+
+for pack in $BASE_PACKAGES; do
+  (
+    cd "packages/$pack"
+    echo "Publishing $pack"
+    cargo publish
+  )
+done
+
+# wait for these to be processed on crates.io
+echo "Waiting for publishing base packages"
+sleep $SLEEP_TIME
+
+for pack in $ALL_PACKAGES; do
+  (
+    cd "packages/$pack"
+    echo "Publishing $pack"
+    cargo publish
+  )
+done
+
+# wait for these to be processed on crates.io
+echo "Waiting for publishing all packages"
+sleep $SLEEP_TIME
+
+for cont in $BASE_CONTRACTS; do
+  (
+    cd "contracts/$cont"
+    echo "Publishing $cont"
+    cargo publish
+  )
+done
+
+# wait for these to be processed on crates.io
+echo "Waiting for publishing base packages"
+sleep $SLEEP_TIME
+
+for cont in $ALL_CONTRACTS; do
+  (
+    cd "contracts/$cont"
+    echo "Publishing $cont"
+    cargo publish
+  )
+done
+
+echo "Everything is published!"

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+function print_usage() {
+  echo "Usage: $0 NEW_VERSION"
+  echo ""
+  echo "e.g. $0 0.8.0"
+}
+
+if [ "$#" -ne 1 ]; then
+    print_usage
+    exit 1
+fi
+
+# Check repo
+SCRIPT_DIR="$(realpath "$(dirname "$0")")"
+if [[ "$(realpath "$SCRIPT_DIR/..")" != "$(pwd)" ]]; then
+  echo "Script must be called from the repo root"
+  exit 2
+fi
+
+# Ensure repo is not dirty
+CHANGES_IN_REPO=$(git status --porcelain)
+if [[ -n "$CHANGES_IN_REPO" ]]; then
+    echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+    git status && git --no-pager diff
+    exit 3
+fi
+
+NEW="$1"
+OLD=$(sed -n -e 's/^version[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' packages/cw20/Cargo.toml)
+echo "Updating old version $OLD to new version $NEW ..."
+
+FILES_MODIFIED=()
+
+for package_dir in packages/*/; do
+  CARGO_TOML="$package_dir/Cargo.toml"
+  sed -i -e "s/version[[:space:]]*=[[:space:]]*\"$OLD\"/version = \"$NEW\"/" "$CARGO_TOML"
+  FILES_MODIFIED+=("$CARGO_TOML")
+done
+
+for contract_dir in contracts/*/; do
+  CARGO_TOML="$contract_dir/Cargo.toml"
+  sed -i -e "s/version[[:space:]]*=[[:space:]]*\"$OLD\"/version = \"$NEW\"/" "$CARGO_TOML"
+  FILES_MODIFIED+=("$CARGO_TOML")
+done
+
+cargo build
+FILES_MODIFIED+=("Cargo.lock")
+
+echo "Staging ${FILES_MODIFIED[*]} ..."
+git add "${FILES_MODIFIED[@]}"
+git commit -m "Set version: $NEW"


### PR DESCRIPTION
Closes #63 

Add a migration path for `cw20-base` from v0.1.x to v0.2.0, and test the changes work.

This demos how a migration could work and also brings up a number of points on testing infrastructure we will need to make testing this easier. 