### PR TITLE
Cw20coin refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,12 +275,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -411,7 +411,6 @@ dependencies = [
  "cosmwasm-vm",
  "cw2",
  "cw20",
- "cw20-escrow",
  "hex 0.3.2",
  "schemars",
  "serde",
@@ -598,12 +597,9 @@ checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
-dependencies = [
- "autocfg",
-]
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "hermit-abi"
@@ -628,9 +624,9 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "indexmap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -651,9 +647,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "lock_api"
@@ -799,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
 ]
@@ -1053,15 +1049,15 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/cw20-atomic-swap/Cargo.toml
+++ b/contracts/cw20-atomic-swap/Cargo.toml
@@ -18,7 +18,6 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 library = []
 
 [dependencies]
-cw20-escrow = { path = "../cw20-escrow", version = "0.2.0", features = ["library"] }
 cw2 = { path = "../../packages/cw2", version = "0.2.0" }
 cw20 = { path = "../../packages/cw20", version = "0.2.0" }
 cosmwasm-std = { version = "0.10.0", features = ["iterator"] }

--- a/contracts/cw20-atomic-swap/src/balance.rs
+++ b/contracts/cw20-atomic-swap/src/balance.rs
@@ -2,8 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::Coin;
-
-use cw20_escrow::state::Cw20Coin;
+use cw20::Cw20Coin;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/cw20-atomic-swap/src/contract.rs
+++ b/contracts/cw20-atomic-swap/src/contract.rs
@@ -5,9 +5,7 @@ use cosmwasm_std::{
     HumanAddr, InitResponse, Querier, StdError, StdResult, Storage, WasmMsg,
 };
 use cw2::set_contract_version;
-use cw20::{Cw20HandleMsg, Cw20ReceiveMsg};
-
-use cw20_escrow::state::Cw20Coin;
+use cw20::{Cw20Coin, Cw20CoinHuman, Cw20HandleMsg, Cw20ReceiveMsg};
 
 use crate::balance::Balance;
 use crate::msg::{
@@ -15,7 +13,6 @@ use crate::msg::{
     QueryMsg, ReceiveMsg,
 };
 use crate::state::{all_swap_ids, atomic_swaps, atomic_swaps_read, AtomicSwap};
-use cw20_escrow::msg::Cw20CoinHuman;
 
 // Version info, for migration info
 const CONTRACT_NAME: &str = "crates.io:cw20-atomic-swap";
@@ -735,7 +732,7 @@ mod tests {
             amount: cw20_coin.amount,
             msg: Some(to_binary(&HandleMsg::Create(create)).unwrap()),
         };
-        let token_contract = cw20_coin.address; // TODO: Confirm
+        let token_contract = cw20_coin.address;
         let env = mock_env(&token_contract, &[]);
         let res = handle(&mut deps, env, HandleMsg::Receive(receive.clone())).unwrap();
         assert_eq!(0, res.messages.len());

--- a/contracts/cw20-atomic-swap/src/msg.rs
+++ b/contracts/cw20-atomic-swap/src/msg.rs
@@ -2,8 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Coin, HumanAddr};
-use cw20::{Cw20ReceiveMsg, Expiration};
-use cw20_escrow::msg::Cw20CoinHuman;
+use cw20::{Cw20CoinHuman, Cw20ReceiveMsg, Expiration};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct InitMsg {}

--- a/contracts/cw20-escrow/src/contract.rs
+++ b/contracts/cw20-escrow/src/contract.rs
@@ -2,15 +2,14 @@ use cosmwasm_std::{
     from_binary, log, to_binary, Api, BankMsg, Binary, Coin, CosmosMsg, Env, Extern,
     HandleResponse, HumanAddr, InitResponse, Querier, StdError, StdResult, Storage, WasmMsg,
 };
+use cosmwasm_storage::prefixed;
 use cw2::set_contract_version;
-use cw20::{Cw20HandleMsg, Cw20ReceiveMsg};
+use cw20::{Cw20Coin, Cw20CoinHuman, Cw20HandleMsg, Cw20ReceiveMsg};
 
 use crate::msg::{
-    CreateMsg, Cw20CoinHuman, DetailsResponse, HandleMsg, InitMsg, ListResponse, QueryMsg,
-    ReceiveMsg,
+    CreateMsg, DetailsResponse, HandleMsg, InitMsg, ListResponse, QueryMsg, ReceiveMsg,
 };
-use crate::state::{all_escrow_ids, escrows, escrows_read, Cw20Coin, Escrow, PREFIX_ESCROW};
-use cosmwasm_storage::prefixed;
+use crate::state::{all_escrow_ids, escrows, escrows_read, Escrow, PREFIX_ESCROW};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw20-escrow";

--- a/contracts/cw20-escrow/src/msg.rs
+++ b/contracts/cw20-escrow/src/msg.rs
@@ -1,7 +1,9 @@
-use cosmwasm_std::{Api, CanonicalAddr, Coin, HumanAddr, StdResult, Uint128};
-use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{Api, CanonicalAddr, Coin, HumanAddr, StdResult};
+
+use cw20::{Cw20CoinHuman, Cw20ReceiveMsg};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct InitMsg {}
@@ -118,10 +120,4 @@ pub struct DetailsResponse {
     pub cw20_balance: Vec<Cw20CoinHuman>,
     /// Whitelisted cw20 tokens
     pub cw20_whitelist: Vec<HumanAddr>,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct Cw20CoinHuman {
-    pub address: HumanAddr,
-    pub amount: Uint128,
 }

--- a/contracts/cw20-escrow/src/state.rs
+++ b/contracts/cw20-escrow/src/state.rs
@@ -3,9 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
     Api, CanonicalAddr, Coin, Env, HumanAddr, Order, ReadonlyStorage, StdError, StdResult, Storage,
-    Uint128,
 };
 use cosmwasm_storage::{bucket, bucket_read, prefixed_read, Bucket, ReadonlyBucket};
+
+use cw20::Cw20Coin;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 pub struct Escrow {
@@ -28,12 +29,6 @@ pub struct Escrow {
     pub cw20_balance: Vec<Cw20Coin>,
     /// All possible contracts that we accept tokens from
     pub cw20_whitelist: Vec<CanonicalAddr>,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct Cw20Coin {
-    pub address: CanonicalAddr,
-    pub amount: Uint128,
 }
 
 impl Escrow {

--- a/packages/cw20/src/coin.rs
+++ b/packages/cw20/src/coin.rs
@@ -1,0 +1,16 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{CanonicalAddr, HumanAddr, Uint128};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct Cw20Coin {
+    pub address: CanonicalAddr,
+    pub amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct Cw20CoinHuman {
+    pub address: HumanAddr,
+    pub amount: Uint128,
+}

--- a/packages/cw20/src/lib.rs
+++ b/packages/cw20/src/lib.rs
@@ -1,3 +1,4 @@
+mod coin;
 mod helpers;
 mod msg;
 mod query;
@@ -5,6 +6,7 @@ mod receiver;
 
 pub use cw0::Expiration;
 
+pub use crate::coin::{Cw20Coin, Cw20CoinHuman};
 pub use crate::helpers::{Cw20CanonicalContract, Cw20Contract};
 pub use crate::msg::Cw20HandleMsg;
 pub use crate::query::{


### PR DESCRIPTION
A small PR to move `Cw20Coin` to the `cw20` package (closes #73).

Will also add coin normalization (#76) to cw20-atomic-swaps here.