### PR TITLE
Use Include/Exclude Bounds to define range searches

### DIFF
--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -299,6 +299,21 @@ over all items with `range(store, min, max, order)`. It supports `Order::Ascendi
 `min` is the lower bound and `max` is the higher bound.
 
 ```rust
+#[derive(Copy, Clone, Debug)]
+pub enum Bound<'a> {
+    Inclusive(&'a [u8]),
+    Exclusive(&'a [u8]),
+    None,
+}
+```
+
+If the `min` and `max` bounds, it will return all items under this prefix. You can use `.take(n)` to
+limit the results to `n` items and start doing pagination. You can also set the `min` bound to
+eg. `Bound::Exclusive(last_value)` to start iterating over all items *after* the last value. Combined with
+`take`, we easily have pagination support. You can also use `Bound::Inclusive(x)` when you want to include any
+perfect matches. To better understand the API, please read the following example:
+
+```rust
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 struct Data {
     pub name: String,
@@ -330,7 +345,7 @@ fn demo() -> StdResult<()> {
     let all: StdResult<Vec<_>> = PEOPLE
         .range(
             &store,
-            Bound::Exclude(b"jim"),
+            Bound::Exclusive(b"jim"),
             Bound::None,
             Order::Ascending,
         )
@@ -357,8 +372,8 @@ fn demo() -> StdResult<()> {
         .prefix(b"owner")
         .range(
             &store,
-            Bound::Exclude(b"spender1"),
-            Bound::Include(b"spender2"),
+            Bound::Exclusive(b"spender1"),
+            Bound::Inclusive(b"spender2"),
             Order::Descending,
         )
         .collect();

--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -288,9 +288,85 @@ fn demo() -> StdResult<()> {
 
 ### Prefix 
 
-We
+In addition to getting one particular item out of a map, we can iterate over the map
+(or a subset of the map). This let's us answer questions like "show me all tokens",
+and we provide some nice `Bound`s helpers to easily allow pagination or custom ranges.
 
-**TODO**
+The general format is to get a `Prefix` by calling `map.prefix(k)`, where `k` is exactly
+one less item than the normal key (If `map.key()` took `(&[u8], &[u8])`, then `map.prefix()` takes `&[u8]`.
+If `map.key()` took `&[u8]`, `map.prefix()` takes `()`). Once we have a prefix space, we can iterate
+over all items with `range(store, min, max, order)`. It supports `Order::Ascending` or `Order::Descending`.
+`min` is the lower bound and `max` is the higher bound.
+
+```rust
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+struct Data {
+    pub name: String,
+    pub age: i32,
+}
+
+const PEOPLE: Map<&[u8], Data> = Map::new(b"people");
+const ALLOWANCE: Map<(&[u8], &[u8]), u64> = Map::new(b"allow");
+
+fn demo() -> StdResult<()> {
+    let mut store = MockStorage::new();
+
+    // save and load on two keys
+    let data = Data { name: "John".to_string(), age: 32 };
+    PEOPLE.save(&mut store, b"john", &data)?;
+    let data2 = Data { name: "Jim".to_string(), age: 44 };
+    PEOPLE.save(&mut store, b"jim", &data2)?;
+
+    // iterate over them all
+    let all: StdResult<Vec<_>> = PEOPLE
+        .range(&store, Bound::None, Bound::None, Order::Ascending)
+        .collect();
+    assert_eq!(
+        all?,
+        vec![(b"jim".to_vec(), data2), (b"john".to_vec(), data.clone())]
+    );
+
+    // or just show what is after jim
+    let all: StdResult<Vec<_>> = PEOPLE
+        .range(
+            &store,
+            Bound::Exclude(b"jim"),
+            Bound::None,
+            Order::Ascending,
+        )
+        .collect();
+    assert_eq!(all?, vec![(b"john".to_vec(), data)]);
+
+    // save and load on three keys, one under different owner
+    ALLOWANCE.save(&mut store, (b"owner", b"spender"), &1000)?;
+    ALLOWANCE.save(&mut store, (b"owner", b"spender2"), &3000)?;
+    ALLOWANCE.save(&mut store, (b"owner2", b"spender"), &5000)?;
+
+    // get all under one key
+    let all: StdResult<Vec<_>> = ALLOWANCE
+        .prefix(b"owner")
+        .range(&store, Bound::None, Bound::None, Order::Ascending)
+        .collect();
+    assert_eq!(
+        all?,
+        vec![(b"spender".to_vec(), 1000), (b"spender2".to_vec(), 3000)]
+    );
+
+    // Or ranges between two items (even reverse)
+    let all: StdResult<Vec<_>> = ALLOWANCE
+        .prefix(b"owner")
+        .range(
+            &store,
+            Bound::Exclude(b"spender1"),
+            Bound::Include(b"spender2"),
+            Order::Descending,
+        )
+        .collect();
+    assert_eq!(all?, vec![(b"spender2".to_vec(), 3000)]);
+
+    Ok(())
+}
+```
 
 ## Indexed Map
 

--- a/packages/storage-plus/src/iter_helpers.rs
+++ b/packages/storage-plus/src/iter_helpers.rs
@@ -15,6 +15,7 @@ pub(crate) fn deserialize_kv<T: DeserializeOwned>(kv: KV) -> StdResult<KV<T>> {
 
 /// Calculates the raw key prefix for a given namespace as documented
 /// in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
+#[allow(dead_code)]
 pub(crate) fn to_length_prefixed(namespace: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(namespace.len() + 2);
     out.extend_from_slice(&encode_length(namespace));

--- a/packages/storage-plus/src/iter_helpers.rs
+++ b/packages/storage-plus/src/iter_helpers.rs
@@ -2,8 +2,8 @@
 
 use serde::de::DeserializeOwned;
 
+use cosmwasm_std::KV;
 use cosmwasm_std::{from_slice, StdResult};
-use cosmwasm_std::{Order, Storage, KV};
 
 use crate::helpers::encode_length;
 
@@ -22,60 +22,16 @@ pub(crate) fn to_length_prefixed(namespace: &[u8]) -> Vec<u8> {
     out
 }
 
-pub(crate) fn range_with_prefix<'a, S: Storage>(
-    storage: &'a S,
-    namespace: &[u8],
-    start: Option<&[u8]>,
-    end: Option<&[u8]>,
-    order: Order,
-) -> Box<dyn Iterator<Item = KV> + 'a> {
-    // prepare start, end with prefix
-    let start = match start {
-        Some(s) => concat(namespace, s),
-        None => namespace.to_vec(),
-    };
-    let end = match end {
-        Some(e) => concat(namespace, e),
-        // end is updating last byte by one
-        None => namespace_upper_bound(namespace),
-    };
-
-    // get iterator from storage
-    let base_iterator = storage.range(Some(&start), Some(&end), order);
-
-    // make a copy for the closure to handle lifetimes safely
-    let prefix = namespace.to_vec();
-    let mapped = base_iterator.map(move |(k, v)| (trim(&prefix, &k), v));
-    Box::new(mapped)
-}
-
 #[inline]
-fn trim(namespace: &[u8], key: &[u8]) -> Vec<u8> {
+pub(crate) fn trim(namespace: &[u8], key: &[u8]) -> Vec<u8> {
     key[namespace.len()..].to_vec()
 }
 
 #[inline]
-fn concat(namespace: &[u8], key: &[u8]) -> Vec<u8> {
+pub(crate) fn concat(namespace: &[u8], key: &[u8]) -> Vec<u8> {
     let mut k = namespace.to_vec();
     k.extend_from_slice(key);
     k
-}
-
-/// Returns a new vec of same length and last byte incremented by one
-/// If last bytes are 255, we handle overflow up the chain.
-/// If all bytes are 255, this returns wrong data - but that is never possible as a namespace
-fn namespace_upper_bound(input: &[u8]) -> Vec<u8> {
-    let mut copy = input.to_vec();
-    // zero out all trailing 255, increment first that is not such
-    for i in (0..input.len()).rev() {
-        if copy[i] == 255 {
-            copy[i] = 0;
-        } else {
-            copy[i] += 1;
-            break;
-        }
-    }
-    copy
 }
 
 #[cfg(test)]

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -85,14 +85,14 @@ where
     pub fn range<'c, S: Storage>(
         &self,
         store: &'c S,
-        start: Bound<'_>,
-        end: Bound<'_>,
+        min: Bound<'_>,
+        max: Bound<'_>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::KV<T>>> + 'c>
     where
         T: 'c,
     {
-        self.prefix(()).range(store, start, end, order)
+        self.prefix(()).range(store, min, max, order)
     }
 }
 
@@ -392,7 +392,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE
             .range(
                 &store,
-                Bound::Exclude(b"jim"),
+                Bound::Exclusive(b"jim"),
                 Bound::None,
                 Order::Ascending,
             )
@@ -419,8 +419,8 @@ mod test {
             .prefix(b"owner")
             .range(
                 &store,
-                Bound::Exclude(b"spender1"),
-                Bound::Include(b"spender2"),
+                Bound::Exclusive(b"spender1"),
+                Bound::Inclusive(b"spender2"),
                 Order::Descending,
             )
             .collect();

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -7,7 +7,7 @@ use crate::keys::Prefixer;
 use crate::keys::PrimaryKey;
 use crate::path::Path;
 #[cfg(feature = "iterator")]
-use crate::prefix::{range_with_prefix, Bound, Prefix};
+use crate::prefix::{Bound, Prefix};
 use cosmwasm_std::{StdError, StdResult, Storage};
 
 pub struct Map<'a, K, T> {
@@ -83,18 +83,16 @@ where
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
     pub fn range<'c, S: Storage>(
-        &'c self,
+        &self,
         store: &'c S,
         start: Bound<'_>,
         end: Bound<'_>,
         order: cosmwasm_std::Order,
-    ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::KV<T>>> + 'c> {
-        // put the imports here, so we don't have to feature flag them above
-        use crate::iter_helpers::{deserialize_kv, to_length_prefixed};
-
-        let prefix = to_length_prefixed(self.namespace);
-        let mapped = range_with_prefix(store, &prefix, start, end, order).map(deserialize_kv::<T>);
-        Box::new(mapped)
+    ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::KV<T>>> + 'c>
+    where
+        T: 'c,
+    {
+        self.prefix(()).range(store, start, end, order)
     }
 }
 

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -122,6 +122,7 @@ mod test {
     use super::*;
     use cosmwasm_std::testing::MockStorage;
 
+    #[test]
     fn ensure_proper_range_bounds() {
         let mut store = MockStorage::new();
         // manually create this - not testing nested prefixes here
@@ -139,11 +140,11 @@ mod test {
         store.set(b"font", b"200");
 
         let expected = vec![
-            (b"foobar".to_vec(), 1u64),
-            (b"foora".to_vec(), 2u64),
-            (b"foozi".to_vec(), 3u64),
+            (b"bar".to_vec(), 1u64),
+            (b"ra".to_vec(), 2u64),
+            (b"zi".to_vec(), 3u64),
         ];
-        let expected_reversed: Vec<(Vec<u8>, u64)> = expected.iter().clone().rev().collect();
+        let expected_reversed: Vec<(Vec<u8>, u64)> = expected.iter().rev().cloned().collect();
 
         // let's do the basic sanity check
         let res: StdResult<Vec<_>> = prefix
@@ -157,105 +158,90 @@ mod test {
 
         // now let's check some ascending ranges
         let res: StdResult<Vec<_>> = prefix
-            .range(
-                &store,
-                Bound::Include(b"foora"),
-                Bound::None,
-                Order::Ascending,
-            )
+            .range(&store, Bound::Include(b"ra"), Bound::None, Order::Ascending)
             .collect();
-        assert_eq!(&expected[1..], &res.unwrap());
+        assert_eq!(&expected[1..], res.unwrap().as_slice());
         // skip excluded
         let res: StdResult<Vec<_>> = prefix
-            .range(
-                &store,
-                Bound::Exclude(b"foora"),
-                Bound::None,
-                Order::Ascending,
-            )
+            .range(&store, Bound::Exclude(b"ra"), Bound::None, Order::Ascending)
             .collect();
-        assert_eq!(&expected[2..], &res.unwrap());
+        assert_eq!(&expected[2..], res.unwrap().as_slice());
         // if we exclude something a little lower, we get matched
         let res: StdResult<Vec<_>> = prefix
-            .range(
-                &store,
-                Bound::Exclude(b"foor"),
-                Bound::None,
-                Order::Ascending,
-            )
+            .range(&store, Bound::Exclude(b"r"), Bound::None, Order::Ascending)
             .collect();
-        assert_eq!(&expected[1..], &res.unwrap());
+        assert_eq!(&expected[1..], res.unwrap().as_slice());
 
         // now let's check some descending ranges
         let res: StdResult<Vec<_>> = prefix
             .range(
                 &store,
                 Bound::None,
-                Bound::Include(b"foora"),
+                Bound::Include(b"ra"),
                 Order::Descending,
             )
             .collect();
-        assert_eq!(&expected_reversed[1..], &res.unwrap());
+        assert_eq!(&expected_reversed[1..], res.unwrap().as_slice());
         // skip excluded
         let res: StdResult<Vec<_>> = prefix
             .range(
                 &store,
                 Bound::None,
-                Bound::Exclude(b"foora"),
+                Bound::Exclude(b"ra"),
                 Order::Descending,
             )
             .collect();
-        assert_eq!(&expected_reversed[2..], &res.unwrap());
+        assert_eq!(&expected_reversed[2..], res.unwrap().as_slice());
         // if we exclude something a little higher, we get matched
         let res: StdResult<Vec<_>> = prefix
             .range(
                 &store,
                 Bound::None,
-                Bound::Exclude(b"foorb"),
+                Bound::Exclude(b"rb"),
                 Order::Descending,
             )
             .collect();
-        assert_eq!(&expected_reversed[1..], &res.unwrap());
+        assert_eq!(&expected_reversed[1..], res.unwrap().as_slice());
 
         // now test when both sides are set
         let res: StdResult<Vec<_>> = prefix
             .range(
                 &store,
-                Bound::Include(b"foora"),
-                Bound::Exclude(b"foozi"),
+                Bound::Include(b"ra"),
+                Bound::Exclude(b"zi"),
                 Order::Ascending,
             )
             .collect();
-        assert_eq!(&expected[1..2], &res.unwrap());
+        assert_eq!(&expected[1..2], res.unwrap().as_slice());
         // and descending
         let res: StdResult<Vec<_>> = prefix
             .range(
                 &store,
-                Bound::Include(b"foora"),
-                Bound::Exclude(b"foozi"),
+                Bound::Include(b"ra"),
+                Bound::Exclude(b"zi"),
                 Order::Descending,
             )
             .collect();
-        assert_eq!(&expected[1..2], &res.unwrap());
+        assert_eq!(&expected[1..2], res.unwrap().as_slice());
         // Include both sides
         let res: StdResult<Vec<_>> = prefix
             .range(
                 &store,
-                Bound::Include(b"foora"),
-                Bound::Include(b"foozi"),
+                Bound::Include(b"ra"),
+                Bound::Include(b"zi"),
                 Order::Descending,
             )
             .collect();
-        assert_eq!(&expected_reversed[..2], &res.unwrap());
+        assert_eq!(&expected_reversed[..2], res.unwrap().as_slice());
         // Exclude both sides
         let res: StdResult<Vec<_>> = prefix
             .range(
                 &store,
-                Bound::Exclude(b"foora"),
-                Bound::Exclude(b"foozi"),
+                Bound::Exclude(b"ra"),
+                Bound::Exclude(b"zi"),
                 Order::Ascending,
             )
             .collect();
-        assert_eq!(&[], &res.unwrap());
+        assert_eq!(res.unwrap().as_slice(), &[]);
     }
 }

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -43,12 +43,15 @@ where
     }
 
     pub fn range<'a, S: Storage>(
-        &'a self,
+        &self,
         store: &'a S,
         start: Bound<'_>,
         end: Bound<'_>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'a> {
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'a>
+    where
+        T: 'a,
+    {
         let mapped = range_with_prefix(store, &self.storage_prefix, start, end, order)
             .map(deserialize_kv::<T>);
         Box::new(mapped)


### PR DESCRIPTION
I think this is what you were suggesting Mauro - public API doesn't require bit-twiddling.

This is incomplete and definitely missing tests, but please review the idea (and maybe suggest a better path forward).

When we agree on a proper interface and implement it, then I will use the new `Item` and `Map` and `Prefix/Bound` types to reimplement the storage of `cw3-fixed-multisig` as a real world test case. 

- [x] Finalize Range API
- [x] Solid unit tests (edge conditions, both Ascending and Descending)
- [x] Document in README
- [ ] (Move/copy code samples to rustdocs?)
- [ ] Ensure wasmd has same boundary behavior
- [ ] Update `cw3-fixed-multisig` to new API

Once this is out, I would love to cut a `0.3.0` release, and then we can add secondary indexes in `0.3.1` as a non-breaking change