### PR TITLE
Migrate cw3-fixed-multisig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ version = "0.2.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
+ "cw-storage-plus",
  "cw0",
  "cw2",
  "cw3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -177,7 +177,7 @@ name = "cw2"
 version = "0.2.3"
 dependencies = [
  "cosmwasm-std",
- "cosmwasm-storage",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -21,8 +21,8 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.2.3" }
 cw2 = { path = "../../packages/cw2", version = "0.2.3" }
 cw3 = { path = "../../packages/cw3", version = "0.2.3" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.2.3", features = ["iterator"] }
 cosmwasm-std = { version = "0.11.0", features = ["iterator"] }
-cosmwasm-storage = { version = "0.11.0", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -386,6 +386,7 @@ fn query_vote<S: Storage, A: Api, Q: Querier>(
     Ok(VoteResponse { vote })
 }
 
+// TODO: pull this out into a helper - one for Canonical as well
 fn make_exclusive_bound<A: Api>(api: A, limit: Option<HumanAddr>) -> StdResult<OwnedBound> {
     let canon: Option<CanonicalAddr> = limit.map(|x| api.canonical_address(&x)).transpose()?;
     let start = match canon {

--- a/packages/cw0/src/lib.rs
+++ b/packages/cw0/src/lib.rs
@@ -4,4 +4,6 @@ mod pagination;
 
 pub use crate::balance::NativeBalance;
 pub use crate::expiration::{Duration, Expiration, DAY, HOUR, WEEK};
-pub use pagination::{calc_range_end_human, calc_range_start_human, calc_range_start_string};
+pub use pagination::{
+    calc_range_end_human, calc_range_start_human, calc_range_start_string, maybe_canonical,
+};

--- a/packages/cw0/src/pagination.rs
+++ b/packages/cw0/src/pagination.rs
@@ -1,4 +1,12 @@
-use cosmwasm_std::{Api, HumanAddr, StdResult};
+use cosmwasm_std::{Api, CanonicalAddr, HumanAddr, StdResult};
+
+// this is used for pagination. Maybe we move it into the std lib one day?
+pub fn maybe_canonical<A: Api>(
+    api: A,
+    human: Option<HumanAddr>,
+) -> StdResult<Option<CanonicalAddr>> {
+    human.map(|x| api.canonical_address(&x)).transpose()
+}
 
 // this will set the first key after the provided key, by appending a 0 byte
 pub fn calc_range_start_human<A: Api>(

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -11,6 +11,6 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "0.11.0" }
-cosmwasm-storage = { version = "0.11.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.2.3" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage-plus"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Enhanced/experimental storage engines"

--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -2,7 +2,7 @@
 
 The ideas in here are based on the `cosmwasm-storage` crate. However,
 after much usage, we decided a complete rewrite could allow us to add
-more powerful and easy touse interfaces. Here are those interfaces.
+more powerful and easy to use interfaces. Here are those interfaces.
 
 **Status: experimental**
 
@@ -11,7 +11,8 @@ repo. This is a first draft of many types. We will update the status
 after they have been used more heavily and the interfaces stabilized.
 
 The ideas/desired functionality in here should be more or final, 
-just the form to express them which will keep changing.
+just the form to express them that is not final. As we add new functionality,
+we will continue to refine the foundations, but maintain semver.
 
 ## Usage Overview
 
@@ -19,7 +20,7 @@ We introduce two main classes to provide a productive abstraction
 on top of `cosmwasm_std::Storage`. They are `Item`, which is
 a typed wrapper around one database key, providing some helper functions
 for interacting with it without dealing with raw bytes. And `Map`,
-which allows you to store multiple typed objects under a prefix,
+which allows you to store multiple unique typed objects under a prefix,
 indexed by a simple (`&[u8]`) or compound (eg. `(&[u8], &[u8])`) primary key.
 
 These correspond to the concepts represented in `cosmwasm_storage` by
@@ -110,7 +111,7 @@ eg. `(owner, spender)` to look up the balance.
 Beyond direct lookups, we have a super power not found in Ethereum -
 iteration. That's right, you can list all items in a `Map`, or only
 part of them. We can efficiently allow pagination over these items as
-well, starting after the last query ended at low, low gas costs.
+well, starting at the point the last query ended, with low gas costs.
 This requires the `iterator` feature to be enabled in `cw-storage-plus`
 (which automatically enables it in `cosmwasm-std` as well).
 
@@ -191,7 +192,7 @@ fn demo() -> StdResult<()> {
 
 There are times when we want to use multiple items as a key, for example, when
 storing allowances based on account owner and spender. We could try to manually
-concatenate them before calling, but that can lead ot overlap, and is a bit
+concatenate them before calling, but that can lead to overlap, and is a bit
 low-level for us. Also, by explicitly separating the keys, we can easily provide
 helpers to do range queries over a prefix, such as "show me all allowances for
 one owner" (first part of the composite key). Just like you'd expect from your

--- a/packages/storage-plus/src/endian.rs
+++ b/packages/storage-plus/src/endian.rs
@@ -7,7 +7,7 @@
 use std::mem;
 
 pub trait Endian: Sized + Copy {
-    type Buf: AsRef<[u8]> + AsMut<[u8]> + Default;
+    type Buf: AsRef<[u8]> + AsMut<[u8]> + Into<Vec<u8>> + Default;
 
     fn to_le_bytes(self) -> Self::Buf;
     fn to_be_bytes(self) -> Self::Buf;

--- a/packages/storage-plus/src/endian.rs
+++ b/packages/storage-plus/src/endian.rs
@@ -1,0 +1,55 @@
+//! This code is inspired by (and partially borrowed from)
+//! https://docs.rs/endiannezz/0.5.2/endiannezz/trait.Primitive.html
+//! but there was a lot in that crate I did not want, the name did not inspire
+//! confidence, and I wanted a different return value, so I just took the code
+//! to modify slightly.
+
+use std::mem;
+
+pub trait Endian: Sized + Copy {
+    type Buf: AsRef<[u8]> + AsMut<[u8]> + Default;
+
+    fn to_le_bytes(self) -> Self::Buf;
+    fn to_be_bytes(self) -> Self::Buf;
+
+    fn from_le_bytes(bytes: Self::Buf) -> Self;
+    fn from_be_bytes(bytes: Self::Buf) -> Self;
+}
+
+macro_rules! delegate {
+    ($ty:ty, [$($method:ident),* $(,)?], ($param:ident : $param_ty:ty) -> $ret:ty) => {
+        delegate!(@inner $ty, [$($method),*], $param, $param_ty, $ret);
+    };
+    (@inner $ty:ty, [$($method:ident),*], $param:ident, $param_ty:ty, $ret:ty) => {
+        $(
+            #[inline]
+            fn $method ($param: $param_ty) -> $ret { <$ty>::$method($param) }
+        )*
+    };
+}
+
+macro_rules! impl_primitives {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl Endian for $ty {
+                type Buf = [u8; mem::size_of::<$ty>()];
+
+                delegate!($ty, [
+                    to_le_bytes,
+                    to_be_bytes,
+                ], (self: Self) -> Self::Buf);
+
+                delegate!($ty, [
+                    from_le_bytes,
+                    from_be_bytes,
+                ], (bytes: Self::Buf) -> Self);
+            }
+        )*
+    };
+}
+
+#[rustfmt::skip]
+impl_primitives![
+    i8, i16, i32, i64, i128,
+    u8, u16, u32, u64, u128,
+];

--- a/packages/storage-plus/src/item.rs
+++ b/packages/storage-plus/src/item.rs
@@ -29,6 +29,11 @@ impl<'a, T> Item<'a, T>
 where
     T: Serialize + DeserializeOwned,
 {
+    // this gets the path of the data to use elsewhere
+    pub fn as_slice(&self) -> &[u8] {
+        self.storage_key
+    }
+
     /// save will serialize the model and store, returns an error on serialization issues
     pub fn save<S: Storage>(&self, store: &mut S, data: &T) -> StdResult<()> {
         store.set(self.storage_key, &to_vec(data)?);

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -66,9 +66,7 @@ pub trait EmptyPrefix {
 }
 
 impl EmptyPrefix for () {
-    fn new() -> Self {
-        ()
-    }
+    fn new() {}
 }
 
 // Add support for an dynamic keys - constructor functions below

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -2,13 +2,18 @@ pub trait PrimaryKey<'a> {
     type Prefix: Prefixer<'a>;
 
     /// returns a slice of key steps, which can be optionally combined
-    fn key(&self) -> Vec<&'a [u8]>;
+    fn key<'b>(&'b self) -> Vec<&'b [u8]>
+    where
+        'a: 'b;
 }
 
 impl<'a> PrimaryKey<'a> for &'a [u8] {
     type Prefix = ();
 
-    fn key(&self) -> Vec<&'a [u8]> {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]>
+    where
+        'a: 'b,
+    {
         // this is simple, we don't add more prefixes
         vec![self]
     }
@@ -17,7 +22,10 @@ impl<'a> PrimaryKey<'a> for &'a [u8] {
 impl<'a> PrimaryKey<'a> for (&'a [u8], &'a [u8]) {
     type Prefix = &'a [u8];
 
-    fn key(&self) -> Vec<&'a [u8]> {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]>
+    where
+        'a: 'b,
+    {
         vec![self.0, self.1]
     }
 }
@@ -25,7 +33,10 @@ impl<'a> PrimaryKey<'a> for (&'a [u8], &'a [u8]) {
 impl<'a> PrimaryKey<'a> for (&'a [u8], &'a [u8], &'a [u8]) {
     type Prefix = (&'a [u8], &'a [u8]);
 
-    fn key(&self) -> Vec<&'a [u8]> {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]>
+    where
+        'a: 'b,
+    {
         vec![self.0, self.1, self.2]
     }
 }
@@ -50,5 +61,36 @@ impl<'a> Prefixer<'a> for &'a [u8] {
 impl<'a> Prefixer<'a> for (&'a [u8], &'a [u8]) {
     fn prefix(&self) -> Vec<&'a [u8]> {
         vec![self.0, self.1]
+    }
+}
+
+// Add support for an dynamic keys - constructor functions below
+pub struct Pk1Owned(pub Vec<u8>);
+
+pub fn u64_key(val: u64) -> Pk1Owned {
+    Pk1Owned(val.to_be_bytes().into())
+}
+
+impl<'a> PrimaryKey<'a> for Pk1Owned {
+    type Prefix = ();
+
+    fn key<'b>(&'b self) -> Vec<&'b [u8]>
+    where
+        'a: 'b,
+    {
+        vec![&self.0]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn u64key_works() {
+        let k = u64_key(134);
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(134u64.to_be_bytes().to_vec(), path[0].to_vec());
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -74,6 +74,9 @@ impl EmptyPrefix for () {
 // Add support for an dynamic keys - constructor functions below
 pub struct PkOwned(pub Vec<u8>);
 
+// FIXME: simplify all this - I think we can just implement generic for AsRef<&[u8]> and most of the rest falls awayy?
+// But then I hit lifetime issues....
+
 impl<'a> PrimaryKey<'a> for PkOwned {
     type Prefix = ();
 
@@ -118,7 +121,7 @@ pub struct IntKey<T: Endian> {
 impl<T: Endian> IntKey<T> {
     pub fn new(val: T) -> Self {
         IntKey {
-            wrapped: PkOwned(val.to_be_bytes().as_ref().to_vec()),
+            wrapped: PkOwned(val.to_be_bytes().into()),
             data: PhantomData,
         }
     }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -60,6 +60,17 @@ impl<'a> Prefixer<'a> for (&'a [u8], &'a [u8]) {
     }
 }
 
+// this is a marker for the Map.range() helper, so we can detect () in Generic bounds
+pub trait EmptyPrefix {
+    fn new() -> Self;
+}
+
+impl EmptyPrefix for () {
+    fn new() -> Self {
+        ()
+    }
+}
+
 // Add support for an dynamic keys - constructor functions below
 pub struct PkOwned(pub Vec<u8>);
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -67,10 +67,6 @@ impl<'a> Prefixer<'a> for (&'a [u8], &'a [u8]) {
 // Add support for an dynamic keys - constructor functions below
 pub struct Pk1Owned(pub Vec<u8>);
 
-pub fn u64_key(val: u64) -> Pk1Owned {
-    Pk1Owned(val.to_be_bytes().into())
-}
-
 impl<'a> PrimaryKey<'a> for Pk1Owned {
     type Prefix = ();
 
@@ -79,6 +75,38 @@ impl<'a> PrimaryKey<'a> for Pk1Owned {
         'a: 'b,
     {
         vec![&self.0]
+    }
+}
+
+impl<'a, T: AsRef<Pk1Owned>> PrimaryKey<'a> for T {
+    type Prefix = ();
+
+    fn key<'b>(&'b self) -> Vec<&'b [u8]>
+    where
+        'a: 'b,
+    {
+        self.as_ref().key()
+    }
+}
+
+// this reuses Pk1Owned logic with a particular type
+pub struct U64Key(pub Pk1Owned);
+
+impl U64Key {
+    pub fn new(val: u64) -> Self {
+        U64Key(Pk1Owned(val.to_be_bytes().to_vec()))
+    }
+}
+
+impl From<u64> for U64Key {
+    fn from(val: u64) -> Self {
+        U64Key::new(val)
+    }
+}
+
+impl AsRef<Pk1Owned> for U64Key {
+    fn as_ref(&self) -> &Pk1Owned {
+        &self.0
     }
 }
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -5,18 +5,13 @@ pub trait PrimaryKey<'a> {
     type Prefix: Prefixer<'a>;
 
     /// returns a slice of key steps, which can be optionally combined
-    fn key<'b>(&'b self) -> Vec<&'b [u8]>
-    where
-        'a: 'b;
+    fn key<'b>(&'b self) -> Vec<&'b [u8]>;
 }
 
 impl<'a> PrimaryKey<'a> for &'a [u8] {
     type Prefix = ();
 
-    fn key<'b>(&'b self) -> Vec<&'b [u8]>
-    where
-        'a: 'b,
-    {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]> {
         // this is simple, we don't add more prefixes
         vec![self]
     }
@@ -25,10 +20,7 @@ impl<'a> PrimaryKey<'a> for &'a [u8] {
 impl<'a> PrimaryKey<'a> for (&'a [u8], &'a [u8]) {
     type Prefix = &'a [u8];
 
-    fn key<'b>(&'b self) -> Vec<&'b [u8]>
-    where
-        'a: 'b,
-    {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]> {
         vec![self.0, self.1]
     }
 }
@@ -36,10 +28,7 @@ impl<'a> PrimaryKey<'a> for (&'a [u8], &'a [u8]) {
 impl<'a> PrimaryKey<'a> for (&'a [u8], &'a [u8], &'a [u8]) {
     type Prefix = (&'a [u8], &'a [u8]);
 
-    fn key<'b>(&'b self) -> Vec<&'b [u8]>
-    where
-        'a: 'b,
-    {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]> {
         vec![self.0, self.1, self.2]
     }
 }
@@ -73,10 +62,7 @@ pub struct Pk1Owned(pub Vec<u8>);
 impl<'a> PrimaryKey<'a> for Pk1Owned {
     type Prefix = ();
 
-    fn key<'b>(&'b self) -> Vec<&'b [u8]>
-    where
-        'a: 'b,
-    {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]> {
         vec![&self.0]
     }
 }
@@ -85,10 +71,7 @@ impl<'a> PrimaryKey<'a> for Pk1Owned {
 impl<'a, T: AsRef<Pk1Owned>> PrimaryKey<'a> for T {
     type Prefix = ();
 
-    fn key<'b>(&'b self) -> Vec<&'b [u8]>
-    where
-        'a: 'b,
-    {
+    fn key<'b>(&'b self) -> Vec<&'b [u8]> {
         self.as_ref().key()
     }
 }

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -9,7 +9,7 @@ mod prefix;
 
 pub use endian::Endian;
 pub use item::Item;
-pub use keys::{Pk1Owned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key};
+pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -1,3 +1,4 @@
+mod endian;
 mod helpers;
 mod item;
 mod iter_helpers;
@@ -6,8 +7,9 @@ mod map;
 mod path;
 mod prefix;
 
+pub use endian::Endian;
 pub use item::Item;
-pub use keys::{Pk1Owned, Prefixer, PrimaryKey, U64Key};
+pub use keys::{Pk1Owned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -13,4 +13,4 @@ pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::Prefix;
+pub use prefix::{Bound, OwnedBound, Prefix};

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -7,7 +7,7 @@ mod path;
 mod prefix;
 
 pub use item::Item;
-pub use keys::{u64_key, Pk1Owned, Prefixer, PrimaryKey};
+pub use keys::{Pk1Owned, Prefixer, PrimaryKey, U64Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -7,7 +7,7 @@ mod path;
 mod prefix;
 
 pub use item::Item;
-pub use keys::{Prefixer, PrimaryKey};
+pub use keys::{u64_key, Pk1Owned, Prefixer, PrimaryKey};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -2,9 +2,9 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::marker::PhantomData;
 
+use crate::keys::PrimaryKey;
 #[cfg(feature = "iterator")]
-use crate::keys::Prefixer;
-use crate::keys::{EmptyPrefix, PrimaryKey};
+use crate::keys::{EmptyPrefix, Prefixer};
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{Bound, Prefix};

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 #[cfg(feature = "iterator")]
 use crate::keys::Prefixer;
-use crate::keys::PrimaryKey;
+use crate::keys::{EmptyPrefix, PrimaryKey};
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{Bound, Prefix};
@@ -76,9 +76,11 @@ where
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
 #[cfg(feature = "iterator")]
-impl<'a, T> Map<'a, &'a [u8], T>
+impl<'a, K, T> Map<'a, K, T>
 where
     T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a>,
+    K::Prefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -92,7 +94,7 @@ where
     where
         T: 'c,
     {
-        self.prefix(()).range(store, min, max, order)
+        self.prefix(K::Prefix::new()).range(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -7,6 +7,7 @@ use cosmwasm_std::{Order, StdResult, Storage, KV};
 
 use crate::helpers::nested_namespaces_with_key;
 use crate::iter_helpers::{concat, deserialize_kv, trim};
+use crate::Endian;
 
 /// Bound is used to defines the two ends of a range, more explicit than Option<u8>
 /// None means that we don't limit that side of the range at all.
@@ -17,6 +18,47 @@ pub enum Bound<'a> {
     Inclusive(&'a [u8]),
     Exclusive(&'a [u8]),
     None,
+}
+
+/// OwnedBound is like bound, but owns the data (as a Vec<u8>) inside.
+/// It is much easier to use if you dynamically construct the content, and can be passed into range as well.
+#[derive(Clone, Debug)]
+pub enum OwnedBound {
+    Inclusive(Vec<u8>),
+    Exclusive(Vec<u8>),
+    None,
+}
+
+impl OwnedBound {
+    pub fn bound<'a>(&'a self) -> Bound<'a> {
+        match self {
+            OwnedBound::Inclusive(limit) => Bound::Inclusive(&limit),
+            OwnedBound::Exclusive(limit) => Bound::Exclusive(&limit),
+            OwnedBound::None => Bound::None,
+        }
+    }
+
+    pub fn inclusive<T: Endian>(limit: T) -> Self {
+        OwnedBound::Inclusive(limit.to_be_bytes().into())
+    }
+
+    pub fn exclusive<T: Endian>(limit: T) -> Self {
+        OwnedBound::Exclusive(limit.to_be_bytes().into())
+    }
+
+    pub fn inclusive_or_none<T: Endian>(limit: Option<T>) -> Self {
+        match limit {
+            Some(t) => Self::inclusive(t),
+            None => OwnedBound::None,
+        }
+    }
+
+    pub fn exclusive_or_none<T: Endian>(limit: Option<T>) -> Self {
+        match limit {
+            Some(t) => Self::exclusive(t),
+            None => OwnedBound::None,
+        }
+    }
 }
 
 pub struct Prefix<T>

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -30,7 +30,7 @@ pub enum OwnedBound {
 }
 
 impl OwnedBound {
-    pub fn bound<'a>(&'a self) -> Bound<'a> {
+    pub fn bound(&self) -> Bound<'_> {
         match self {
             OwnedBound::Inclusive(limit) => Bound::Inclusive(&limit),
             OwnedBound::Exclusive(limit) => Bound::Exclusive(&limit),


### PR DESCRIPTION
Follow up from #116 

`cw3-fixed-multisig` now uses `cw-storage-plus`. Since it made heavy use of integer keys in the Buckets, this pushed for a lot of API extensions, to allow such keys to work. As well as many helpers for creating bounds for dynamic range queries (from options) for pagination. Good stuff to pull in.

Api is untouched. As soon as the code compiled, all tests passed :smile: Gotta love the Rust compiler as a QA partner.

Now that https://github.com/CosmWasm/wasmd/pull/290 validated the bounds as expected, happy to merge.