### PR TITLE
OwnedBound -> Option<Bound>

### DIFF
--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{Binary, Order, StdError, StdResult, Storage, KV};
 
 use crate::map::Map;
 use crate::prefix::range_with_prefix;
-use crate::{Bound, Endian};
+use crate::Endian;
 
 /// MARKER is stored in the multi-index as value, but we only look at the key (which is pk)
 const MARKER: u32 = 1;
@@ -86,8 +86,8 @@ where
 {
     pub fn pks<'c>(&self, store: &'c S, idx: &[u8]) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         let prefix = self.idx_map.prefix(idx);
-        let mapped = range_with_prefix(store, &prefix, Bound::None, Bound::None, Order::Ascending)
-            .map(|(k, _)| k);
+        let mapped =
+            range_with_prefix(store, &prefix, None, None, Order::Ascending).map(|(k, _)| k);
         Box::new(mapped)
     }
 

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -19,4 +19,4 @@ pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::{Bound, OwnedBound, Prefix};
+pub use prefix::{Bound, Prefix};

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -88,8 +88,8 @@ where
     pub fn range<'c, S: Storage>(
         &self,
         store: &'c S,
-        min: Bound<'_>,
-        max: Bound<'_>,
+        min: Option<Bound>,
+        max: Option<Bound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::KV<T>>> + 'c>
     where
@@ -200,9 +200,7 @@ mod test {
         PEOPLE.save(&mut store, b"jim", &data2).unwrap();
 
         // let's try to iterate!
-        let all: StdResult<Vec<_>> = PEOPLE
-            .range(&store, Bound::None, Bound::None, Order::Ascending)
-            .collect();
+        let all: StdResult<Vec<_>> = PEOPLE.range(&store, None, None, Order::Ascending).collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
         assert_eq!(
@@ -230,7 +228,7 @@ mod test {
         // let's try to iterate!
         let all: StdResult<Vec<_>> = ALLOWANCE
             .prefix(b"owner")
-            .range(&store, Bound::None, Bound::None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
@@ -384,9 +382,7 @@ mod test {
         PEOPLE.save(&mut store, b"jim", &data2)?;
 
         // iterate over them all
-        let all: StdResult<Vec<_>> = PEOPLE
-            .range(&store, Bound::None, Bound::None, Order::Ascending)
-            .collect();
+        let all: StdResult<Vec<_>> = PEOPLE.range(&store, None, None, Order::Ascending).collect();
         assert_eq!(
             all?,
             vec![(b"jim".to_vec(), data2), (b"john".to_vec(), data.clone())]
@@ -396,8 +392,8 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE
             .range(
                 &store,
-                Bound::Exclusive(b"jim"),
-                Bound::None,
+                Some(Bound::Exclusive(b"jim".to_vec())),
+                None,
                 Order::Ascending,
             )
             .collect();
@@ -411,7 +407,7 @@ mod test {
         // get all under one key
         let all: StdResult<Vec<_>> = ALLOWANCE
             .prefix(b"owner")
-            .range(&store, Bound::None, Bound::None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         assert_eq!(
             all?,
@@ -423,8 +419,8 @@ mod test {
             .prefix(b"owner")
             .range(
                 &store,
-                Bound::Exclusive(b"spender1"),
-                Bound::Inclusive(b"spender2"),
+                Some(Bound::Exclusive(b"spender1".to_vec())),
+                Some(Bound::Inclusive(b"spender2".to_vec())),
                 Order::Descending,
             )
             .collect();


### PR DESCRIPTION
Only use one type with simpler helpers. Using Option allows us to make better use of the map function.

This makes some internal tests on `cw-storage-plus` more verbose, but the usage in other contracts simpler.