### PR TITLE
Fix SendNft in Cw721-base

### DIFF
--- a/packages/cw721/schema/cw721_receive_msg.json
+++ b/packages/cw721/schema/cw721_receive_msg.json
@@ -4,13 +4,10 @@
   "description": "Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a HandleMsg",
   "type": "object",
   "required": [
-    "amount",
-    "sender"
+    "sender",
+    "token_id"
   ],
   "properties": {
-    "amount": {
-      "$ref": "#/definitions/Uint128"
-    },
     "msg": {
       "anyOf": [
         {
@@ -23,6 +20,9 @@
     },
     "sender": {
       "$ref": "#/definitions/HumanAddr"
+    },
+    "token_id": {
+      "type": "string"
     }
   },
   "definitions": {
@@ -31,9 +31,6 @@
       "type": "string"
     },
     "HumanAddr": {
-      "type": "string"
-    },
-    "Uint128": {
       "type": "string"
     }
   }

--- a/packages/cw721/src/receiver.rs
+++ b/packages/cw721/src/receiver.rs
@@ -1,14 +1,14 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{to_binary, Binary, CosmosMsg, HumanAddr, StdResult, Uint128, WasmMsg};
+use cosmwasm_std::{to_binary, Binary, CosmosMsg, HumanAddr, StdResult, WasmMsg};
 
 /// Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a HandleMsg
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct Cw721ReceiveMsg {
     pub sender: HumanAddr,
-    pub amount: Uint128,
+    pub token_id: String,
     pub msg: Option<Binary>,
 }
 


### PR DESCRIPTION
- [x] Fix cw721: The receiver type in code now matches the readme
- [x] Fix cw721-base: Send the proper message when SendNft is executed.