### PR TITLE
Support multiple messages in CanExecute query

### DIFF
--- a/contracts/cw1-subkeys/schema/query_msg.json
+++ b/contracts/cw1-subkeys/schema/query_msg.json
@@ -64,12 +64,15 @@
         "can_execute": {
           "type": "object",
           "required": [
-            "msg",
+            "msgs",
             "sender"
           ],
           "properties": {
-            "msg": {
-              "$ref": "#/definitions/CosmosMsg_for_Empty"
+            "msgs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
             },
             "sender": {
               "$ref": "#/definitions/HumanAddr"

--- a/contracts/cw1-subkeys/src/msg.rs
+++ b/contracts/cw1-subkeys/src/msg.rs
@@ -63,7 +63,7 @@ where
     /// before any further state changes, should also succeed.
     CanExecute {
         sender: HumanAddr,
-        msg: CosmosMsg<T>,
+        msgs: Vec<CosmosMsg<T>>,
     },
     /// Gets all Allowances for this contract
     /// Returns AllAllowancesResponse

--- a/contracts/cw1-whitelist/schema/query_msg.json
+++ b/contracts/cw1-whitelist/schema/query_msg.json
@@ -24,12 +24,15 @@
         "can_execute": {
           "type": "object",
           "required": [
-            "msg",
+            "msgs",
             "sender"
           ],
           "properties": {
-            "msg": {
-              "$ref": "#/definitions/CosmosMsg_for_Empty"
+            "msgs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
             },
             "sender": {
               "$ref": "#/definitions/HumanAddr"

--- a/contracts/cw1-whitelist/src/msg.rs
+++ b/contracts/cw1-whitelist/src/msg.rs
@@ -40,7 +40,7 @@ where
     /// before any further state changes, should also succeed.
     CanExecute {
         sender: HumanAddr,
-        msg: CosmosMsg<T>,
+        msgs: Vec<CosmosMsg<T>>,
     },
 }
 

--- a/packages/cw1/schema/can_execute_response.json
+++ b/packages/cw1/schema/can_execute_response.json
@@ -7,7 +7,10 @@
   ],
   "properties": {
     "can_execute": {
-      "type": "boolean"
+      "type": "array",
+      "items": {
+        "type": "boolean"
+      }
     }
   }
 }

--- a/packages/cw1/src/query.rs
+++ b/packages/cw1/src/query.rs
@@ -21,5 +21,5 @@ where
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct CanExecuteResponse {
-    pub can_execute: bool,
+    pub can_execute: Vec<bool>,
 }


### PR DESCRIPTION
Closes the last part of #145, supporting multiple messages in CanExecute query.