### PR TITLE
Separate multisig from group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
       - contract_cw1_subkeys
       - contract_cw1_whitelist
       - contract_cw3_fixed_multisig
+      - contract_cw3_flex_multisig
       - contract_cw4_group
       - contract_cw20_atomic_swap
       - contract_cw20_base
@@ -175,6 +176,41 @@ jobs:
             - /usr/local/cargo/registry
             - target
           key: cargocache-cw3-fixed-multisig-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+
+  contract_cw3_flex_multisig:
+    docker:
+      - image: rust:1.47.0
+    working_directory: ~/project/contracts/cw3-flex-multisig
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version
+      - restore_cache:
+          keys:
+            - cargocache-cw3-flex-multisig-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+      - run:
+          name: Unit Tests
+          env: RUST_BACKTRACE=1
+          command: cargo unit-test --locked
+      - run:
+          name: Build and run schema generator
+          command: cargo schema --locked
+      - run:
+          name: Ensure checked-in schemas are up-to-date
+          command: |
+            CHANGES_IN_REPO=$(git status --porcelain)
+            if [[ -n "$CHANGES_IN_REPO" ]]; then
+              echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+              git status && git --no-pager diff
+              exit 1
+            fi
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target
+          key: cargocache-cw3-flex-multisig-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw4_group:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,11 +259,13 @@ version = "0.3.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-multi-test",
  "cw-storage-plus",
  "cw0",
  "cw2",
  "cw3",
  "cw4",
+ "cw4-group",
  "schemars",
  "serde",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw3-flex-multisig"
+version = "0.3.2"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
+ "cw2",
+ "cw3",
+ "cw4",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw4"
 version = "0.3.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ incremental = false
 codegen-units = 1
 incremental = false
 
+[profile.release.package.cw3-flex-multisig]
+codegen-units = 1
+incremental = false
+
 [profile.release.package.cw4-group]
 codegen-units = 1
 incremental = false

--- a/contracts/cw20-escrow/src/integration_test.rs
+++ b/contracts/cw20-escrow/src/integration_test.rs
@@ -7,7 +7,7 @@ use cw_multi_test::{App, Contract, ContractWrapper, SimpleBank};
 
 use crate::msg::{CreateMsg, DetailsResponse, HandleMsg, InitMsg, QueryMsg, ReceiveMsg};
 
-fn mock_router() -> App {
+fn mock_app() -> App {
     let env = mock_env();
     let api = Box::new(MockApi::default());
     let bank = SimpleBank {};
@@ -36,7 +36,7 @@ pub fn contract_cw20() -> Box<dyn Contract> {
 #[test]
 // receive cw20 tokens and release upon approval
 fn escrow_happy_path_cw20_tokens() {
-    let mut router = mock_router();
+    let mut router = mock_app();
 
     // set personal balance
     let owner = HumanAddr::from("owner");

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -438,7 +438,7 @@ fn list_voters(
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{coin, from_binary, BankMsg};
 
     use cw0::Duration;
@@ -598,7 +598,7 @@ mod tests {
         setup_test_case(deps.as_mut(), info.clone(), required_weight, voting_period).unwrap();
 
         let bank_msg = BankMsg::Send {
-            from_address: OWNER.into(),
+            from_address: MOCK_CONTRACT_ADDR.into(),
             to_address: SOMEBODY.into(),
             amount: vec![coin(1, "BTC")],
         };
@@ -689,7 +689,7 @@ mod tests {
 
         // Propose
         let bank_msg = BankMsg::Send {
-            from_address: OWNER.into(),
+            from_address: MOCK_CONTRACT_ADDR.into(),
             to_address: SOMEBODY.into(),
             amount: vec![coin(1, "BTC")],
         };
@@ -843,7 +843,7 @@ mod tests {
 
         // Propose
         let bank_msg = BankMsg::Send {
-            from_address: OWNER.into(),
+            from_address: MOCK_CONTRACT_ADDR.into(),
             to_address: SOMEBODY.into(),
             amount: vec![coin(1, "BTC")],
         };
@@ -946,7 +946,7 @@ mod tests {
 
         // Propose
         let bank_msg = BankMsg::Send {
-            from_address: OWNER.into(),
+            from_address: MOCK_CONTRACT_ADDR.into(),
             to_address: SOMEBODY.into(),
             amount: vec![coin(1, "BTC")],
         };

--- a/contracts/cw3-flex-multisig/.cargo/config
+++ b/contracts/cw3-flex-multisig/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+integration-test = "test --test integration"
+schema = "run --example schema"

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -30,3 +30,5 @@ thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.12.0" }
+cw4-group = { path = "../cw4-group", version = "0.3.2" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.3.2" }

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "cw3-flex-multisig"
+version = "0.3.2"
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+edition = "2018"
+description = "Implementing cw3 with multiple voting patterns and dynamic groups"
+license = "Apache-2.0"
+repository = "https://github.com/CosmWasm/cosmwasm-plus"
+homepage = "https://cosmwasm.com"
+documentation = "https://docs.cosmwasm.com"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all init/handle/query exports
+library = []
+
+[dependencies]
+cw0 = { path = "../../packages/cw0", version = "0.3.2" }
+cw2 = { path = "../../packages/cw2", version = "0.3.2" }
+cw3 = { path = "../../packages/cw3", version = "0.3.2" }
+cw4 = { path = "../../packages/cw4", version = "0.3.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.3.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.12.0", features = ["iterator"] }
+schemars = "0.7"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.20" }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "0.12.0" }

--- a/contracts/cw3-flex-multisig/NOTICE
+++ b/contracts/cw3-flex-multisig/NOTICE
@@ -1,0 +1,14 @@
+CW3-Flex-Whitelist: Implementing cw3 with multiple voting patterns and dynamic groups
+Copyright (C) 2020 Confio OÜ
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/contracts/cw3-flex-multisig/README.md
+++ b/contracts/cw3-flex-multisig/README.md
@@ -1,0 +1,67 @@
+# CW3 Flexible Multisig
+
+**TODO** rewrite this - this is copy for fixed multisig
+
+This is a simple implementation of the [cw3 spec](../../packages/cw3/README.md).
+It is a multisig with a fixed set of addresses created upon initialization.
+Each address may have the same weight (K of N) or some may have extra voting
+power. This works much like the native Cosmos SDK multisig, except that rather
+than aggregating the signatures off chain and submitting the final result,
+we aggregate the approvals on-chain.
+
+This is usable as is, and probably the most secure implementation of cw3
+(as it is the simplest), but we will be adding more complex cases, such
+as updating the multisig set, different voting rules for the same group
+with different permissions, and even allow token-weighted voting. All through
+the same client interface.
+
+## Init
+
+To create the multisig, you must pass in a set of `HumanAddr` with a weight
+for each one, as well as a required weight to pass a proposal. To create
+a 2 of 3 multisig, pass 3 voters with weight 1 and a `required_weight` of 2.
+
+Note that 0 *is an allowed weight*. This doesn't give any voting rights, but
+it does allow that key to submit proposals that can later be approved by the
+voters. Any address not in the voter set cannot submit a proposal.
+
+## Handle Process
+
+First, a registered voter must submit a proposal. This also includes the
+first "Yes" vote on the proposal by the proposer. The proposer can set
+an expiration time for the voting process, or it defaults to the limit
+provided when creating the contract (so proposals can be closed after several
+days).
+
+Before the proposal has expired, any voter with non-zero weight can add their
+vote. Only "Yes" votes are tallied. If enough "Yes" votes were submitted before
+the proposal expiration date, the status is set to "Passed".
+
+Once a proposal is "Passed", anyone may submit an "Execute" message. This will
+trigger the proposal to send all stored messages from the proposal and update
+it's state to "Executed", so it cannot run again. (Note if the execution fails
+for any reason - out of gas, insufficient funds, etc - the state update will
+be reverted and it will remain "Passed" so you can try again).
+
+Once a proposal has expired without passing, anyone can submit a "Close"
+message to mark it closed. This has no effect beyond cleaning up the UI/database.
+
+## Running this contract
+
+You will need Rust 1.44.1+ with `wasm32-unknown-unknown` target installed.
+
+You can run unit tests on this via: 
+
+`cargo test`
+
+Once you are happy with the content, you can compile it to wasm via:
+
+```
+RUSTFLAGS='-C link-arg=-s' cargo wasm
+cp ../../target/wasm32-unknown-unknown/release/cw3_fixed_multisig.wasm .
+ls -l cw3_fixed_multisig.wasm
+sha256sum cw3_fixed_multisig.wasm
+```
+
+Or for a production-ready (optimized) build, run a build command in the
+the repository root: https://github.com/CosmWasm/cosmwasm-plus#compiling.

--- a/contracts/cw3-flex-multisig/examples/schema.rs
+++ b/contracts/cw3-flex-multisig/examples/schema.rs
@@ -1,0 +1,17 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
+
+use cw3_fixed_multisig::msg::{HandleMsg, InitMsg, QueryMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InitMsg), &out_dir);
+    export_schema_with_title(&mut schema_for!(HandleMsg), &out_dir, "HandleMsg");
+    export_schema_with_title(&mut schema_for!(QueryMsg), &out_dir, "QueryMsg");
+}

--- a/contracts/cw3-flex-multisig/examples/schema.rs
+++ b/contracts/cw3-flex-multisig/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 
-use cw3_fixed_multisig::msg::{HandleMsg, InitMsg, QueryMsg};
+use cw3_flex_multisig::msg::{HandleMsg, InitMsg, QueryMsg};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/cw3-flex-multisig/schema/handle_msg.json
+++ b/contracts/cw3-flex-multisig/schema/handle_msg.json
@@ -1,0 +1,472 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "HandleMsg",
+  "anyOf": [
+    {
+      "type": "object",
+      "required": [
+        "propose"
+      ],
+      "properties": {
+        "propose": {
+          "type": "object",
+          "required": [
+            "description",
+            "msgs",
+            "title"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "latest": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "msgs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
+            },
+            "title": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "vote"
+      ],
+      "properties": {
+        "vote": {
+          "type": "object",
+          "required": [
+            "proposal_id",
+            "vote"
+          ],
+          "properties": {
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "vote": {
+              "$ref": "#/definitions/Vote"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "execute"
+      ],
+      "properties": {
+        "execute": {
+          "type": "object",
+          "required": [
+            "proposal_id"
+          ],
+          "properties": {
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "close"
+      ],
+      "properties": {
+        "close": {
+          "type": "object",
+          "required": [
+            "proposal_id"
+          ],
+          "properties": {
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "BankMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "send"
+          ],
+          "properties": {
+            "send": {
+              "type": "object",
+              "required": [
+                "amount",
+                "from_address",
+                "to_address"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                },
+                "from_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "to_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "CosmosMsg_for_Empty": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "bank"
+          ],
+          "properties": {
+            "bank": {
+              "$ref": "#/definitions/BankMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "$ref": "#/definitions/Empty"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "staking"
+          ],
+          "properties": {
+            "staking": {
+              "$ref": "#/definitions/StakingMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "wasm"
+          ],
+          "properties": {
+            "wasm": {
+              "$ref": "#/definitions/WasmMsg"
+            }
+          }
+        }
+      ]
+    },
+    "Empty": {
+      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "type": "object"
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "anyOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          }
+        }
+      ]
+    },
+    "HumanAddr": {
+      "type": "string"
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Uint128": {
+      "type": "string"
+    },
+    "Vote": {
+      "type": "string",
+      "enum": [
+        "yes",
+        "no",
+        "abstain",
+        "veto"
+      ]
+    },
+    "WasmMsg": {
+      "anyOf": [
+        {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "type": "object",
+          "required": [
+            "execute"
+          ],
+          "properties": {
+            "execute": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "send"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "type": "object",
+          "required": [
+            "instantiate"
+          ],
+          "properties": {
+            "instantiate": {
+              "type": "object",
+              "required": [
+                "code_id",
+                "msg",
+                "send"
+              ],
+              "properties": {
+                "code_id": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "label": {
+                  "description": "optional human-readbale label for the contract",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "msg": {
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contracts/cw3-flex-multisig/schema/init_msg.json
+++ b/contracts/cw3-flex-multisig/schema/init_msg.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InitMsg",
+  "type": "object",
+  "required": [
+    "max_voting_period",
+    "required_weight",
+    "voters"
+  ],
+  "properties": {
+    "max_voting_period": {
+      "$ref": "#/definitions/Duration"
+    },
+    "required_weight": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "voters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Voter"
+      }
+    }
+  },
+  "definitions": {
+    "Duration": {
+      "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "height"
+          ],
+          "properties": {
+            "height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "time"
+          ],
+          "properties": {
+            "time": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      ]
+    },
+    "HumanAddr": {
+      "type": "string"
+    },
+    "Voter": {
+      "type": "object",
+      "required": [
+        "addr",
+        "weight"
+      ],
+      "properties": {
+        "addr": {
+          "$ref": "#/definitions/HumanAddr"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    }
+  }
+}

--- a/contracts/cw3-flex-multisig/schema/init_msg.json
+++ b/contracts/cw3-flex-multisig/schema/init_msg.json
@@ -3,11 +3,14 @@
   "title": "InitMsg",
   "type": "object",
   "required": [
+    "group",
     "max_voting_period",
-    "required_weight",
-    "voters"
+    "required_weight"
   ],
   "properties": {
+    "group": {
+      "$ref": "#/definitions/HumanAddr"
+    },
     "max_voting_period": {
       "$ref": "#/definitions/Duration"
     },
@@ -15,12 +18,6 @@
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
-    },
-    "voters": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Voter"
-      }
     }
   },
   "definitions": {
@@ -57,23 +54,6 @@
     },
     "HumanAddr": {
       "type": "string"
-    },
-    "Voter": {
-      "type": "object",
-      "required": [
-        "addr",
-        "weight"
-      ],
-      "properties": {
-        "addr": {
-          "$ref": "#/definitions/HumanAddr"
-        },
-        "weight": {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        }
-      }
     }
   }
 }

--- a/contracts/cw3-flex-multisig/schema/init_msg.json
+++ b/contracts/cw3-flex-multisig/schema/init_msg.json
@@ -3,12 +3,12 @@
   "title": "InitMsg",
   "type": "object",
   "required": [
-    "group",
+    "group_addr",
     "max_voting_period",
     "required_weight"
   ],
   "properties": {
-    "group": {
+    "group_addr": {
       "$ref": "#/definitions/HumanAddr"
     },
     "max_voting_period": {

--- a/contracts/cw3-flex-multisig/schema/query_msg.json
+++ b/contracts/cw3-flex-multisig/schema/query_msg.json
@@ -1,0 +1,223 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "anyOf": [
+    {
+      "description": "Return ThresholdResponse",
+      "type": "object",
+      "required": [
+        "threshold"
+      ],
+      "properties": {
+        "threshold": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "Returns ProposalResponse",
+      "type": "object",
+      "required": [
+        "proposal"
+      ],
+      "properties": {
+        "proposal": {
+          "type": "object",
+          "required": [
+            "proposal_id"
+          ],
+          "properties": {
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Returns ProposalListResponse",
+      "type": "object",
+      "required": [
+        "list_proposals"
+      ],
+      "properties": {
+        "list_proposals": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Returns ProposalListResponse",
+      "type": "object",
+      "required": [
+        "reverse_proposals"
+      ],
+      "properties": {
+        "reverse_proposals": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_before": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Returns VoteResponse",
+      "type": "object",
+      "required": [
+        "vote"
+      ],
+      "properties": {
+        "vote": {
+          "type": "object",
+          "required": [
+            "proposal_id",
+            "voter"
+          ],
+          "properties": {
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "voter": {
+              "$ref": "#/definitions/HumanAddr"
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Returns VoteListResponse",
+      "type": "object",
+      "required": [
+        "list_votes"
+      ],
+      "properties": {
+        "list_votes": {
+          "type": "object",
+          "required": [
+            "proposal_id"
+          ],
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Returns VoterResponse",
+      "type": "object",
+      "required": [
+        "voter"
+      ],
+      "properties": {
+        "voter": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "$ref": "#/definitions/HumanAddr"
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Returns VoterListResponse",
+      "type": "object",
+      "required": [
+        "list_voters"
+      ],
+      "properties": {
+        "list_voters": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "HumanAddr": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -11,12 +11,12 @@ use cw3::{
     ProposalListResponse, ProposalResponse, Status, ThresholdResponse, Vote, VoteInfo,
     VoteListResponse, VoteResponse, VoterListResponse, VoterResponse,
 };
+use cw4::Cw4Contract;
 use cw_storage_plus::Bound;
 
 use crate::error::ContractError;
 use crate::msg::{HandleMsg, InitMsg, QueryMsg};
 use crate::state::{next_id, parse_id, Ballot, Config, Proposal, BALLOTS, CONFIG, PROPOSALS};
-use cw4::Cw4Contract;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw3-flex-multisig";
@@ -445,18 +445,6 @@ mod tests {
     use cw_multi_test::{App, Contract, ContractWrapper, SimpleBank};
 
     use super::*;
-
-    // fn mock_env_height(height_delta: u64) -> Env {
-    //     let mut env = mock_env();
-    //     env.block.height += height_delta;
-    //     env
-    // }
-    //
-    // fn mock_env_time(time_delta: u64) -> Env {
-    //     let mut env = mock_env();
-    //     env.block.time += time_delta;
-    //     env
-    // }
 
     const OWNER: &str = "admin0001";
     const VOTER1: &str = "voter0001";

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -473,24 +473,6 @@ mod tests {
         }
     }
 
-    // fn get_tally(deps: Deps, proposal_id: u64) -> u64 {
-    //     // Get all the voters on the proposal
-    //     let voters = QueryMsg::ListVotes {
-    //         proposal_id,
-    //         start_after: None,
-    //         limit: None,
-    //     };
-    //     let votes: VoteListResponse =
-    //         from_binary(&query(deps, mock_env(), voters).unwrap()).unwrap();
-    //     // Sum the weights of the Yes votes to get the tally
-    //     votes
-    //         .votes
-    //         .iter()
-    //         .filter(|&v| v.vote == Vote::Yes)
-    //         .map(|v| v.weight)
-    //         .sum()
-    // }
-
     pub fn contract_flex() -> Box<dyn Contract> {
         let contract = ContractWrapper::new(
             crate::contract::handle,
@@ -715,159 +697,161 @@ mod tests {
         );
     }
 
-    // #[test]
-    // fn test_vote_works() {
-    //     let mut deps = mock_dependencies(&[]);
-    //
-    //     let required_weight = 3;
-    //     let voting_period = Duration::Time(2000000);
-    //
-    //     let info = mock_info(OWNER, &[]);
-    //     setup_test_case(deps.as_mut(), info.clone(), required_weight, voting_period).unwrap();
-    //
-    //     // Propose
-    //     let bank_msg = BankMsg::Send {
-    //         from_address: OWNER.into(),
-    //         to_address: SOMEBODY.into(),
-    //         amount: vec![coin(1, "BTC")],
-    //     };
-    //     let msgs = vec![CosmosMsg::Bank(bank_msg)];
-    //     let proposal = HandleMsg::Propose {
-    //         title: "Pay somebody".to_string(),
-    //         description: "Do I pay her?".to_string(),
-    //         msgs,
-    //         latest: None,
-    //     };
-    //     let res = handle(deps.as_mut(), mock_env(), info.clone(), proposal).unwrap();
-    //
-    //     // Get the proposal id from the logs
-    //     let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
-    //
-    //     // Owner cannot vote (again)
-    //     let yes_vote = HandleMsg::Vote {
-    //         proposal_id,
-    //         vote: Vote::Yes,
-    //     };
-    //     let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone());
-    //
-    //     // Verify
-    //     assert!(res.is_err());
-    //     match res.unwrap_err() {
-    //         ContractError::AlreadyVoted {} => {}
-    //         e => panic!("unexpected error: {}", e),
-    //     }
-    //
-    //     // Only voters can vote
-    //     let info = mock_info(SOMEBODY, &[]);
-    //     let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone());
-    //
-    //     // Verify
-    //     assert!(res.is_err());
-    //     match res.unwrap_err() {
-    //         ContractError::Unauthorized {} => {}
-    //         e => panic!("unexpected error: {}", e),
-    //     }
-    //
-    //     // But voter1 can
-    //     let info = mock_info(VOTER1, &[]);
-    //     let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone()).unwrap();
-    //
-    //     // Verify
-    //     assert_eq!(
-    //         res,
-    //         HandleResponse {
-    //             messages: vec![],
-    //             attributes: vec![
-    //                 attr("action", "vote"),
-    //                 attr("sender", VOTER1),
-    //                 attr("proposal_id", proposal_id),
-    //                 attr("status", "Open"),
-    //             ],
-    //             data: None,
-    //         }
-    //     );
-    //
-    //     // No/Veto votes have no effect on the tally
-    //     // Get the proposal id from the logs
-    //     let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
-    //
-    //     // Compute the current tally
-    //     let tally = get_tally(deps.as_ref(), proposal_id);
-    //
-    //     // Cast a No vote
-    //     let no_vote = HandleMsg::Vote {
-    //         proposal_id,
-    //         vote: Vote::No,
-    //     };
-    //     let info = mock_info(VOTER2, &[]);
-    //     handle(deps.as_mut(), mock_env(), info, no_vote.clone()).unwrap();
-    //
-    //     // Cast a Veto vote
-    //     let veto_vote = HandleMsg::Vote {
-    //         proposal_id,
-    //         vote: Vote::Veto,
-    //     };
-    //     let info = mock_info(VOTER3, &[]);
-    //     handle(deps.as_mut(), mock_env(), info.clone(), veto_vote).unwrap();
-    //
-    //     // Verify
-    //     assert_eq!(tally, get_tally(deps.as_ref(), proposal_id));
-    //
-    //     // Once voted, votes cannot be changed
-    //     let res = handle(deps.as_mut(), mock_env(), info.clone(), yes_vote.clone());
-    //
-    //     // Verify
-    //     assert!(res.is_err());
-    //     match res.unwrap_err() {
-    //         ContractError::AlreadyVoted {} => {}
-    //         e => panic!("unexpected error: {}", e),
-    //     }
-    //     assert_eq!(tally, get_tally(deps.as_ref(), proposal_id));
-    //
-    //     // Expired proposals cannot be voted
-    //     let env = match voting_period {
-    //         Duration::Time(duration) => mock_env_time(duration + 1),
-    //         Duration::Height(duration) => mock_env_height(duration + 1),
-    //     };
-    //     let res = handle(deps.as_mut(), env, info, no_vote);
-    //
-    //     // Verify
-    //     assert!(res.is_err());
-    //     match res.unwrap_err() {
-    //         ContractError::Expired {} => {}
-    //         e => panic!("unexpected error: {}", e),
-    //     }
-    //
-    //     // Vote it again, so it passes
-    //     let info = mock_info(VOTER4, &[]);
-    //     let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone()).unwrap();
-    //
-    //     // Verify
-    //     assert_eq!(
-    //         res,
-    //         HandleResponse {
-    //             messages: vec![],
-    //             attributes: vec![
-    //                 attr("action", "vote"),
-    //                 attr("sender", VOTER4),
-    //                 attr("proposal_id", proposal_id),
-    //                 attr("status", "Passed"),
-    //             ],
-    //             data: None,
-    //         }
-    //     );
-    //
-    //     // non-Open proposals cannot be voted
-    //     let info = mock_info(VOTER5, &[]);
-    //     let res = handle(deps.as_mut(), mock_env(), info, yes_vote);
-    //
-    //     // Verify
-    //     assert!(res.is_err());
-    //     match res.unwrap_err() {
-    //         ContractError::NotOpen {} => {}
-    //         e => panic!("unexpected error: {}", e),
-    //     }
-    // }
+    fn get_tally(app: &App, flex_addr: &HumanAddr, proposal_id: u64) -> u64 {
+        // Get all the voters on the proposal
+        let voters = QueryMsg::ListVotes {
+            proposal_id,
+            start_after: None,
+            limit: None,
+        };
+        let votes: VoteListResponse = app.wrap().query_wasm_smart(flex_addr, &voters).unwrap();
+        // Sum the weights of the Yes votes to get the tally
+        votes
+            .votes
+            .iter()
+            .filter(|&v| v.vote == Vote::Yes)
+            .map(|v| v.weight)
+            .sum()
+    }
+
+    fn expire(voting_period: Duration) -> impl Fn(&mut BlockInfo) {
+        move |block: &mut BlockInfo| {
+            match voting_period {
+                Duration::Time(duration) => block.time += duration + 1,
+                Duration::Height(duration) => block.height += duration + 1,
+            };
+        }
+    }
+
+    fn unexpire(voting_period: Duration) -> impl Fn(&mut BlockInfo) {
+        move |block: &mut BlockInfo| {
+            match voting_period {
+                Duration::Time(duration) => block.time -= duration,
+                Duration::Height(duration) => block.height -= duration,
+            };
+        }
+    }
+
+    #[test]
+    fn test_vote_works() {
+        let mut app = mock_app();
+
+        let required_weight = 3;
+        let voting_period = Duration::Time(2000000);
+        let flex_addr = setup_test_case(&mut app, required_weight, voting_period, coins(10, "BTC"));
+
+        // Propose
+        let bank_msg = BankMsg::Send {
+            from_address: flex_addr.clone(),
+            to_address: SOMEBODY.into(),
+            amount: coins(1, "BTC"),
+        };
+        let msgs = vec![CosmosMsg::Bank(bank_msg)];
+        let proposal = HandleMsg::Propose {
+            title: "Pay somebody".to_string(),
+            description: "Do I pay her?".to_string(),
+            msgs,
+            latest: None,
+        };
+
+        // create proposal with 0 vote power
+        let res = app
+            .execute_contract(OWNER, &flex_addr, &proposal, &[])
+            .unwrap();
+
+        // Get the proposal id from the logs
+        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+
+        // Owner cannot vote (again)
+        let yes_vote = HandleMsg::Vote {
+            proposal_id,
+            vote: Vote::Yes,
+        };
+        let err = app
+            .execute_contract(OWNER, &flex_addr, &yes_vote, &[])
+            .unwrap_err();
+        assert_eq!(err, ContractError::AlreadyVoted {}.to_string());
+
+        // Only voters can vote
+        let err = app
+            .execute_contract(SOMEBODY, &flex_addr, &yes_vote, &[])
+            .unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {}.to_string());
+
+        // But voter1 can
+        let res = app
+            .execute_contract(VOTER1, &flex_addr, &yes_vote, &[])
+            .unwrap();
+        assert_eq!(
+            res.attributes,
+            vec![
+                attr("action", "vote"),
+                attr("sender", VOTER1),
+                attr("proposal_id", proposal_id),
+                attr("status", "Open"),
+            ],
+        );
+
+        // No/Veto votes have no effect on the tally
+        // Compute the current tally
+        let tally = get_tally(&app, &flex_addr, proposal_id);
+        assert_eq!(tally, 1);
+
+        // Cast a No vote
+        let no_vote = HandleMsg::Vote {
+            proposal_id,
+            vote: Vote::No,
+        };
+        let _ = app
+            .execute_contract(VOTER2, &flex_addr, &no_vote, &[])
+            .unwrap();
+
+        // Cast a Veto vote
+        let veto_vote = HandleMsg::Vote {
+            proposal_id,
+            vote: Vote::Veto,
+        };
+        let _ = app
+            .execute_contract(VOTER3, &flex_addr, &veto_vote, &[])
+            .unwrap();
+
+        // Tally unchanged
+        assert_eq!(tally, get_tally(&app, &flex_addr, proposal_id));
+
+        let err = app
+            .execute_contract(VOTER3, &flex_addr, &yes_vote, &[])
+            .unwrap_err();
+        assert_eq!(err, ContractError::AlreadyVoted {}.to_string());
+
+        // Expired proposals cannot be voted
+        app.update_block(expire(voting_period));
+        let err = app
+            .execute_contract(VOTER4, &flex_addr, &yes_vote, &[])
+            .unwrap_err();
+        assert_eq!(err, ContractError::Expired {}.to_string());
+        app.update_block(unexpire(voting_period));
+
+        // Powerful voter supports it, so it passes
+        let res = app
+            .execute_contract(VOTER4, &flex_addr, &yes_vote, &[])
+            .unwrap();
+        assert_eq!(
+            res.attributes,
+            vec![
+                attr("action", "vote"),
+                attr("sender", VOTER4),
+                attr("proposal_id", proposal_id),
+                attr("status", "Passed"),
+            ],
+        );
+
+        // non-Open proposals cannot be voted
+        let err = app
+            .execute_contract(VOTER5, &flex_addr, &yes_vote, &[])
+            .unwrap_err();
+        assert_eq!(err, ContractError::NotOpen {}.to_string());
+    }
+
     //
     // #[test]
     // fn test_execute_works() {

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -1,0 +1,1030 @@
+use std::cmp::Ordering;
+
+use cosmwasm_std::{
+    attr, to_binary, Binary, BlockInfo, CanonicalAddr, CosmosMsg, Deps, DepsMut, Empty, Env,
+    HandleResponse, HumanAddr, InitResponse, MessageInfo, Order, StdResult,
+};
+
+use cw0::{maybe_canonical, Expiration};
+use cw2::set_contract_version;
+use cw3::{
+    ProposalListResponse, ProposalResponse, Status, ThresholdResponse, Vote, VoteInfo,
+    VoteListResponse, VoteResponse, VoterListResponse, VoterResponse,
+};
+use cw_storage_plus::Bound;
+
+use crate::error::ContractError;
+use crate::msg::{HandleMsg, InitMsg, QueryMsg};
+use crate::state::{
+    next_id, parse_id, Ballot, Config, Proposal, BALLOTS, CONFIG, PROPOSALS, VOTERS,
+};
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:cw3-fixed-multisig";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn init(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InitMsg,
+) -> Result<InitResponse, ContractError> {
+    if msg.required_weight == 0 {
+        return Err(ContractError::ZeroWeight {});
+    }
+    if msg.voters.is_empty() {
+        return Err(ContractError::NoVoters {});
+    }
+    let total_weight = msg.voters.iter().map(|v| v.weight).sum();
+
+    if total_weight < msg.required_weight {
+        return Err(ContractError::UnreachableWeight {});
+    }
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let cfg = Config {
+        required_weight: msg.required_weight,
+        total_weight,
+        max_voting_period: msg.max_voting_period,
+    };
+    CONFIG.save(deps.storage, &cfg)?;
+
+    // add all voters
+    for voter in msg.voters.iter() {
+        let key = deps.api.canonical_address(&voter.addr)?;
+        VOTERS.save(deps.storage, &key, &voter.weight)?;
+    }
+    Ok(InitResponse::default())
+}
+
+pub fn handle(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: HandleMsg,
+) -> Result<HandleResponse<Empty>, ContractError> {
+    match msg {
+        HandleMsg::Propose {
+            title,
+            description,
+            msgs,
+            latest,
+        } => handle_propose(deps, env, info, title, description, msgs, latest),
+        HandleMsg::Vote { proposal_id, vote } => handle_vote(deps, env, info, proposal_id, vote),
+        HandleMsg::Execute { proposal_id } => handle_execute(deps, env, info, proposal_id),
+        HandleMsg::Close { proposal_id } => handle_close(deps, env, info, proposal_id),
+    }
+}
+
+pub fn handle_propose(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    title: String,
+    description: String,
+    msgs: Vec<CosmosMsg>,
+    // we ignore earliest
+    latest: Option<Expiration>,
+) -> Result<HandleResponse<Empty>, ContractError> {
+    // only members of the multisig can create a proposal
+    let raw_sender = deps.api.canonical_address(&info.sender)?;
+    let vote_power = VOTERS
+        .may_load(deps.storage, &raw_sender)?
+        .ok_or_else(|| ContractError::Unauthorized {})?;
+
+    let cfg = CONFIG.load(deps.storage)?;
+
+    // max expires also used as default
+    let max_expires = cfg.max_voting_period.after(&env.block);
+    let mut expires = latest.unwrap_or(max_expires);
+    let comp = expires.partial_cmp(&max_expires);
+    if let Some(Ordering::Greater) = comp {
+        expires = max_expires;
+    } else if comp.is_none() {
+        return Err(ContractError::WrongExpiration {});
+    }
+
+    let status = if vote_power < cfg.required_weight {
+        Status::Open
+    } else {
+        Status::Passed
+    };
+
+    // create a proposal
+    let prop = Proposal {
+        title,
+        description,
+        expires,
+        msgs,
+        status,
+        yes_weight: vote_power,
+        required_weight: cfg.required_weight,
+    };
+    let id = next_id(deps.storage)?;
+    PROPOSALS.save(deps.storage, id.into(), &prop)?;
+
+    // add the first yes vote from voter
+    let ballot = Ballot {
+        weight: vote_power,
+        vote: Vote::Yes,
+    };
+    BALLOTS.save(deps.storage, (id.into(), &raw_sender), &ballot)?;
+
+    Ok(HandleResponse {
+        messages: vec![],
+        attributes: vec![
+            attr("action", "propose"),
+            attr("sender", info.sender),
+            attr("proposal_id", id),
+            attr("status", format!("{:?}", prop.status)),
+        ],
+        data: None,
+    })
+}
+
+pub fn handle_vote(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    proposal_id: u64,
+    vote: Vote,
+) -> Result<HandleResponse<Empty>, ContractError> {
+    // only members of the multisig can vote
+    let raw_sender = deps.api.canonical_address(&info.sender)?;
+    let vote_power = VOTERS
+        .may_load(deps.storage, &raw_sender)?
+        .ok_or_else(|| ContractError::Unauthorized {})?;
+
+    // ensure proposal exists and can be voted on
+    let mut prop = PROPOSALS.load(deps.storage, proposal_id.into())?;
+    if prop.status != Status::Open {
+        return Err(ContractError::NotOpen {});
+    }
+    if prop.expires.is_expired(&env.block) {
+        return Err(ContractError::Expired {});
+    }
+
+    // cast vote if no vote previously cast
+    BALLOTS.update(
+        deps.storage,
+        (proposal_id.into(), &raw_sender),
+        |bal| match bal {
+            Some(_) => Err(ContractError::AlreadyVoted {}),
+            None => Ok(Ballot {
+                weight: vote_power,
+                vote,
+            }),
+        },
+    )?;
+
+    // if yes vote, update tally
+    if vote == Vote::Yes {
+        prop.yes_weight += vote_power;
+        // update status when the passing vote comes in
+        if prop.yes_weight >= prop.required_weight {
+            prop.status = Status::Passed;
+        }
+        PROPOSALS.save(deps.storage, proposal_id.into(), &prop)?;
+    }
+
+    Ok(HandleResponse {
+        messages: vec![],
+        attributes: vec![
+            attr("action", "vote"),
+            attr("sender", info.sender),
+            attr("proposal_id", proposal_id),
+            attr("status", format!("{:?}", prop.status)),
+        ],
+        data: None,
+    })
+}
+
+pub fn handle_execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    proposal_id: u64,
+) -> Result<HandleResponse, ContractError> {
+    // anyone can trigger this if the vote passed
+
+    let mut prop = PROPOSALS.load(deps.storage, proposal_id.into())?;
+    // we allow execution even after the proposal "expiration" as long as all vote come in before
+    // that point. If it was approved on time, it can be executed any time.
+    if prop.status != Status::Passed {
+        return Err(ContractError::WrongExecuteStatus {});
+    }
+
+    // set it to executed
+    prop.status = Status::Executed;
+    PROPOSALS.save(deps.storage, proposal_id.into(), &prop)?;
+
+    // dispatch all proposed messages
+    Ok(HandleResponse {
+        messages: prop.msgs,
+        attributes: vec![
+            attr("action", "execute"),
+            attr("sender", info.sender),
+            attr("proposal_id", proposal_id),
+        ],
+        data: None,
+    })
+}
+
+pub fn handle_close(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    proposal_id: u64,
+) -> Result<HandleResponse<Empty>, ContractError> {
+    // anyone can trigger this if the vote passed
+
+    let mut prop = PROPOSALS.load(deps.storage, proposal_id.into())?;
+    if [Status::Executed, Status::Rejected, Status::Passed]
+        .iter()
+        .any(|x| *x == prop.status)
+    {
+        return Err(ContractError::WrongCloseStatus {});
+    }
+    if !prop.expires.is_expired(&env.block) {
+        return Err(ContractError::NotExpired {});
+    }
+
+    // set it to failed
+    prop.status = Status::Rejected;
+    PROPOSALS.save(deps.storage, proposal_id.into(), &prop)?;
+
+    Ok(HandleResponse {
+        messages: vec![],
+        attributes: vec![
+            attr("action", "close"),
+            attr("sender", info.sender),
+            attr("proposal_id", proposal_id),
+        ],
+        data: None,
+    })
+}
+
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Threshold {} => to_binary(&query_threshold(deps)?),
+        QueryMsg::Proposal { proposal_id } => to_binary(&query_proposal(deps, env, proposal_id)?),
+        QueryMsg::Vote { proposal_id, voter } => to_binary(&query_vote(deps, proposal_id, voter)?),
+        QueryMsg::ListProposals { start_after, limit } => {
+            to_binary(&list_proposals(deps, env, start_after, limit)?)
+        }
+        QueryMsg::ReverseProposals {
+            start_before,
+            limit,
+        } => to_binary(&reverse_proposals(deps, env, start_before, limit)?),
+        QueryMsg::ListVotes {
+            proposal_id,
+            start_after,
+            limit,
+        } => to_binary(&list_votes(deps, proposal_id, start_after, limit)?),
+        QueryMsg::Voter { address } => to_binary(&query_voter(deps, address)?),
+        QueryMsg::ListVoters { start_after, limit } => {
+            to_binary(&list_voters(deps, start_after, limit)?)
+        }
+    }
+}
+
+fn query_threshold(deps: Deps) -> StdResult<ThresholdResponse> {
+    let cfg = CONFIG.load(deps.storage)?;
+    Ok(ThresholdResponse::AbsoluteCount {
+        weight_needed: cfg.required_weight,
+        total_weight: cfg.total_weight,
+    })
+}
+
+fn query_proposal(deps: Deps, env: Env, id: u64) -> StdResult<ProposalResponse> {
+    let prop = PROPOSALS.load(deps.storage, id.into())?;
+    let status = prop.current_status(&env.block);
+    Ok(ProposalResponse {
+        id,
+        title: prop.title,
+        description: prop.description,
+        msgs: prop.msgs,
+        expires: prop.expires,
+        // TODO: check
+        status,
+    })
+}
+
+// settings for pagination
+const MAX_LIMIT: u32 = 30;
+const DEFAULT_LIMIT: u32 = 10;
+
+fn list_proposals(
+    deps: Deps,
+    env: Env,
+    start_after: Option<u64>,
+    limit: Option<u32>,
+) -> StdResult<ProposalListResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.map(Bound::exclusive_int);
+    let props: StdResult<Vec<_>> = PROPOSALS
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|p| map_proposal(&env.block, p))
+        .collect();
+
+    Ok(ProposalListResponse { proposals: props? })
+}
+
+fn reverse_proposals(
+    deps: Deps,
+    env: Env,
+    start_before: Option<u64>,
+    limit: Option<u32>,
+) -> StdResult<ProposalListResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let end = start_before.map(Bound::exclusive_int);
+    let props: StdResult<Vec<_>> = PROPOSALS
+        .range(deps.storage, None, end, Order::Descending)
+        .take(limit)
+        .map(|p| map_proposal(&env.block, p))
+        .collect();
+
+    Ok(ProposalListResponse { proposals: props? })
+}
+
+fn map_proposal(
+    block: &BlockInfo,
+    item: StdResult<(Vec<u8>, Proposal)>,
+) -> StdResult<ProposalResponse> {
+    let (key, prop) = item?;
+    let status = prop.current_status(block);
+    Ok(ProposalResponse {
+        id: parse_id(&key)?,
+        title: prop.title,
+        description: prop.description,
+        msgs: prop.msgs,
+        expires: prop.expires,
+        status,
+    })
+}
+
+fn query_vote(deps: Deps, proposal_id: u64, voter: HumanAddr) -> StdResult<VoteResponse> {
+    let voter_raw = deps.api.canonical_address(&voter)?;
+    let prop = BALLOTS.may_load(deps.storage, (proposal_id.into(), &voter_raw))?;
+    let vote = prop.map(|b| b.vote);
+    Ok(VoteResponse { vote })
+}
+
+fn list_votes(
+    deps: Deps,
+    proposal_id: u64,
+    start_after: Option<HumanAddr>,
+    limit: Option<u32>,
+) -> StdResult<VoteListResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let canon = maybe_canonical(deps.api, start_after)?;
+    let start = canon.map(Bound::exclusive);
+
+    let api = &deps.api;
+    let votes: StdResult<Vec<_>> = BALLOTS
+        .prefix(proposal_id.into())
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|item| {
+            let (key, ballot) = item?;
+            Ok(VoteInfo {
+                voter: api.human_address(&CanonicalAddr::from(key))?,
+                vote: ballot.vote,
+                weight: ballot.weight,
+            })
+        })
+        .collect();
+
+    Ok(VoteListResponse { votes: votes? })
+}
+
+fn query_voter(deps: Deps, voter: HumanAddr) -> StdResult<VoterResponse> {
+    let voter_raw = deps.api.canonical_address(&voter)?;
+    let weight = VOTERS
+        .may_load(deps.storage, &voter_raw)?
+        .unwrap_or_default();
+    Ok(VoterResponse {
+        addr: voter,
+        weight,
+    })
+}
+
+fn list_voters(
+    deps: Deps,
+    start_after: Option<HumanAddr>,
+    limit: Option<u32>,
+) -> StdResult<VoterListResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let canon = maybe_canonical(deps.api, start_after)?;
+    let start = canon.map(Bound::exclusive);
+
+    let api = &deps.api;
+    let voters: StdResult<Vec<_>> = VOTERS
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|item| {
+            let (key, weight) = item?;
+            Ok(VoterResponse {
+                addr: api.human_address(&CanonicalAddr::from(key))?,
+                weight,
+            })
+        })
+        .collect();
+
+    Ok(VoterListResponse { voters: voters? })
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::{coin, from_binary, BankMsg};
+
+    use cw0::Duration;
+    use cw2::{get_contract_version, ContractVersion};
+
+    use crate::msg::Voter;
+
+    use super::*;
+
+    fn mock_env_height(height_delta: u64) -> Env {
+        let mut env = mock_env();
+        env.block.height += height_delta;
+        env
+    }
+
+    fn mock_env_time(time_delta: u64) -> Env {
+        let mut env = mock_env();
+        env.block.time += time_delta;
+        env
+    }
+
+    const OWNER: &str = "admin0001";
+    const VOTER1: &str = "voter0001";
+    const VOTER2: &str = "voter0002";
+    const VOTER3: &str = "voter0003";
+    const VOTER4: &str = "voter0004";
+    const VOTER5: &str = "voter0005";
+    const SOMEBODY: &str = "somebody";
+
+    fn voter<T: Into<HumanAddr>>(addr: T, weight: u64) -> Voter {
+        Voter {
+            addr: addr.into(),
+            weight,
+        }
+    }
+
+    // this will set up the init for other tests
+    fn setup_test_case(
+        deps: DepsMut,
+        info: MessageInfo,
+        required_weight: u64,
+        max_voting_period: Duration,
+    ) -> Result<InitResponse<Empty>, ContractError> {
+        // Init a contract with voters
+        let voters = vec![
+            voter(&info.sender, 0),
+            voter(VOTER1, 1),
+            voter(VOTER2, 2),
+            voter(VOTER3, 3),
+            voter(VOTER4, 4),
+            voter(VOTER5, 5),
+        ];
+
+        let init_msg = InitMsg {
+            voters,
+            required_weight,
+            max_voting_period,
+        };
+        init(deps, mock_env(), info, init_msg)
+    }
+
+    fn get_tally(deps: Deps, proposal_id: u64) -> u64 {
+        // Get all the voters on the proposal
+        let voters = QueryMsg::ListVotes {
+            proposal_id,
+            start_after: None,
+            limit: None,
+        };
+        let votes: VoteListResponse =
+            from_binary(&query(deps, mock_env(), voters).unwrap()).unwrap();
+        // Sum the weights of the Yes votes to get the tally
+        votes
+            .votes
+            .iter()
+            .filter(|&v| v.vote == Vote::Yes)
+            .map(|v| v.weight)
+            .sum()
+    }
+
+    #[test]
+    fn test_init_works() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info(OWNER, &[]);
+
+        let max_voting_period = Duration::Time(1234567);
+
+        // No voters fails
+        let init_msg = InitMsg {
+            voters: vec![],
+            required_weight: 1,
+            max_voting_period,
+        };
+        let res = init(deps.as_mut(), mock_env(), info.clone(), init_msg);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::NoVoters {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Zero required weight fails
+        let init_msg = InitMsg {
+            voters: vec![voter(OWNER, 1)],
+            required_weight: 0,
+            max_voting_period,
+        };
+        let res = init(deps.as_mut(), mock_env(), info.clone(), init_msg);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::ZeroWeight {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Total weight less than required weight not allowed
+        let required_weight = 100;
+        let res = setup_test_case(
+            deps.as_mut(),
+            info.clone(),
+            required_weight,
+            max_voting_period,
+        );
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::UnreachableWeight {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // All valid
+        let required_weight = 1;
+        setup_test_case(deps.as_mut(), info, required_weight, max_voting_period).unwrap();
+
+        // Verify
+        assert_eq!(
+            ContractVersion {
+                contract: CONTRACT_NAME.to_string(),
+                version: CONTRACT_VERSION.to_string(),
+            },
+            get_contract_version(&deps.storage).unwrap()
+        )
+    }
+
+    // TODO: query() tests
+
+    #[test]
+    fn test_propose_works() {
+        let mut deps = mock_dependencies(&[]);
+
+        let required_weight = 4;
+        let voting_period = Duration::Time(2000000);
+
+        let info = mock_info(OWNER, &[]);
+        setup_test_case(deps.as_mut(), info.clone(), required_weight, voting_period).unwrap();
+
+        let bank_msg = BankMsg::Send {
+            from_address: OWNER.into(),
+            to_address: SOMEBODY.into(),
+            amount: vec![coin(1, "BTC")],
+        };
+        let msgs = vec![CosmosMsg::Bank(bank_msg)];
+
+        // Only voters can propose
+        let info = mock_info(SOMEBODY, &[]);
+        let proposal = HandleMsg::Propose {
+            title: "Rewarding somebody".to_string(),
+            description: "Do we reward her?".to_string(),
+            msgs: msgs.clone(),
+            latest: None,
+        };
+        let res = handle(deps.as_mut(), mock_env(), info, proposal.clone());
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::Unauthorized {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Wrong expiration option fails
+        let info = mock_info(OWNER, &[]);
+        let proposal_wrong_exp = HandleMsg::Propose {
+            title: "Rewarding somebody".to_string(),
+            description: "Do we reward her?".to_string(),
+            msgs: msgs.clone(),
+            latest: Some(Expiration::AtHeight(123456)),
+        };
+        let res = handle(deps.as_mut(), mock_env(), info, proposal_wrong_exp);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::WrongExpiration {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Proposal from voter works
+        let info = mock_info(VOTER3, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info, proposal.clone()).unwrap();
+
+        // Verify
+        assert_eq!(
+            res,
+            HandleResponse {
+                messages: vec![],
+                attributes: vec![
+                    attr("action", "propose"),
+                    attr("sender", VOTER3),
+                    attr("proposal_id", 1),
+                    attr("status", "Open"),
+                ],
+                data: None,
+            }
+        );
+
+        // Proposal from voter with enough vote power directly passes
+        let info = mock_info(VOTER4, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info, proposal).unwrap();
+
+        // Verify
+        assert_eq!(
+            res,
+            HandleResponse {
+                messages: vec![],
+                attributes: vec![
+                    attr("action", "propose"),
+                    attr("sender", VOTER4),
+                    attr("proposal_id", 2),
+                    attr("status", "Passed"),
+                ],
+                data: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_vote_works() {
+        let mut deps = mock_dependencies(&[]);
+
+        let required_weight = 3;
+        let voting_period = Duration::Time(2000000);
+
+        let info = mock_info(OWNER, &[]);
+        setup_test_case(deps.as_mut(), info.clone(), required_weight, voting_period).unwrap();
+
+        // Propose
+        let bank_msg = BankMsg::Send {
+            from_address: OWNER.into(),
+            to_address: SOMEBODY.into(),
+            amount: vec![coin(1, "BTC")],
+        };
+        let msgs = vec![CosmosMsg::Bank(bank_msg)];
+        let proposal = HandleMsg::Propose {
+            title: "Pay somebody".to_string(),
+            description: "Do I pay her?".to_string(),
+            msgs,
+            latest: None,
+        };
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), proposal).unwrap();
+
+        // Get the proposal id from the logs
+        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+
+        // Owner cannot vote (again)
+        let yes_vote = HandleMsg::Vote {
+            proposal_id,
+            vote: Vote::Yes,
+        };
+        let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone());
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::AlreadyVoted {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Only voters can vote
+        let info = mock_info(SOMEBODY, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone());
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::Unauthorized {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // But voter1 can
+        let info = mock_info(VOTER1, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone()).unwrap();
+
+        // Verify
+        assert_eq!(
+            res,
+            HandleResponse {
+                messages: vec![],
+                attributes: vec![
+                    attr("action", "vote"),
+                    attr("sender", VOTER1),
+                    attr("proposal_id", proposal_id),
+                    attr("status", "Open"),
+                ],
+                data: None,
+            }
+        );
+
+        // No/Veto votes have no effect on the tally
+        // Get the proposal id from the logs
+        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+
+        // Compute the current tally
+        let tally = get_tally(deps.as_ref(), proposal_id);
+
+        // Cast a No vote
+        let no_vote = HandleMsg::Vote {
+            proposal_id,
+            vote: Vote::No,
+        };
+        let info = mock_info(VOTER2, &[]);
+        handle(deps.as_mut(), mock_env(), info, no_vote.clone()).unwrap();
+
+        // Cast a Veto vote
+        let veto_vote = HandleMsg::Vote {
+            proposal_id,
+            vote: Vote::Veto,
+        };
+        let info = mock_info(VOTER3, &[]);
+        handle(deps.as_mut(), mock_env(), info.clone(), veto_vote).unwrap();
+
+        // Verify
+        assert_eq!(tally, get_tally(deps.as_ref(), proposal_id));
+
+        // Once voted, votes cannot be changed
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), yes_vote.clone());
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::AlreadyVoted {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+        assert_eq!(tally, get_tally(deps.as_ref(), proposal_id));
+
+        // Expired proposals cannot be voted
+        let env = match voting_period {
+            Duration::Time(duration) => mock_env_time(duration + 1),
+            Duration::Height(duration) => mock_env_height(duration + 1),
+        };
+        let res = handle(deps.as_mut(), env, info, no_vote);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::Expired {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Vote it again, so it passes
+        let info = mock_info(VOTER4, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info, yes_vote.clone()).unwrap();
+
+        // Verify
+        assert_eq!(
+            res,
+            HandleResponse {
+                messages: vec![],
+                attributes: vec![
+                    attr("action", "vote"),
+                    attr("sender", VOTER4),
+                    attr("proposal_id", proposal_id),
+                    attr("status", "Passed"),
+                ],
+                data: None,
+            }
+        );
+
+        // non-Open proposals cannot be voted
+        let info = mock_info(VOTER5, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info, yes_vote);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::NotOpen {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    fn test_execute_works() {
+        let mut deps = mock_dependencies(&[]);
+
+        let required_weight = 3;
+        let voting_period = Duration::Time(2000000);
+
+        let info = mock_info(OWNER, &[]);
+        setup_test_case(deps.as_mut(), info.clone(), required_weight, voting_period).unwrap();
+
+        // Propose
+        let bank_msg = BankMsg::Send {
+            from_address: OWNER.into(),
+            to_address: SOMEBODY.into(),
+            amount: vec![coin(1, "BTC")],
+        };
+        let msgs = vec![CosmosMsg::Bank(bank_msg)];
+        let proposal = HandleMsg::Propose {
+            title: "Pay somebody".to_string(),
+            description: "Do I pay her?".to_string(),
+            msgs: msgs.clone(),
+            latest: None,
+        };
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), proposal).unwrap();
+
+        // Get the proposal id from the logs
+        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+
+        // Only Passed can be executed
+        let execution = HandleMsg::Execute { proposal_id };
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), execution.clone());
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::WrongExecuteStatus {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Vote it, so it passes
+        let vote = HandleMsg::Vote {
+            proposal_id,
+            vote: Vote::Yes,
+        };
+        let info = mock_info(VOTER3, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), vote).unwrap();
+
+        // Verify
+        assert_eq!(
+            res,
+            HandleResponse {
+                messages: vec![],
+                attributes: vec![
+                    attr("action", "vote"),
+                    attr("sender", VOTER3),
+                    attr("proposal_id", proposal_id),
+                    attr("status", "Passed"),
+                ],
+                data: None,
+            }
+        );
+
+        // In passing: Try to close Passed fails
+        let closing = HandleMsg::Close { proposal_id };
+        let res = handle(deps.as_mut(), mock_env(), info, closing);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::WrongCloseStatus {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Execute works. Anybody can execute Passed proposals
+        let info = mock_info(SOMEBODY, &[]);
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), execution).unwrap();
+
+        // Verify
+        assert_eq!(
+            res,
+            HandleResponse {
+                messages: msgs,
+                attributes: vec![
+                    attr("action", "execute"),
+                    attr("sender", SOMEBODY),
+                    attr("proposal_id", proposal_id),
+                ],
+                data: None,
+            }
+        );
+
+        // In passing: Try to close Executed fails
+        let closing = HandleMsg::Close { proposal_id };
+        let res = handle(deps.as_mut(), mock_env(), info, closing);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::WrongCloseStatus {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    fn test_close_works() {
+        let mut deps = mock_dependencies(&[]);
+
+        let required_weight = 3;
+        let voting_period = Duration::Height(2000000);
+
+        let info = mock_info(OWNER, &[]);
+        setup_test_case(deps.as_mut(), info.clone(), required_weight, voting_period).unwrap();
+
+        // Propose
+        let bank_msg = BankMsg::Send {
+            from_address: OWNER.into(),
+            to_address: SOMEBODY.into(),
+            amount: vec![coin(1, "BTC")],
+        };
+        let msgs = vec![CosmosMsg::Bank(bank_msg)];
+        let proposal = HandleMsg::Propose {
+            title: "Pay somebody".to_string(),
+            description: "Do I pay her?".to_string(),
+            msgs: msgs.clone(),
+            latest: None,
+        };
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), proposal).unwrap();
+
+        // Get the proposal id from the logs
+        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+
+        let closing = HandleMsg::Close { proposal_id };
+
+        // Anybody can close
+        let info = mock_info(SOMEBODY, &[]);
+
+        // Non-expired proposals cannot be closed
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), closing.clone());
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::NotExpired {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
+        // Expired proposals can be closed
+        let info = mock_info(OWNER, &[]);
+
+        let proposal = HandleMsg::Propose {
+            title: "(Try to) pay somebody".to_string(),
+            description: "Pay somebody after time?".to_string(),
+            msgs: msgs.clone(),
+            latest: Some(Expiration::AtHeight(123456)),
+        };
+        let res = handle(deps.as_mut(), mock_env(), info.clone(), proposal).unwrap();
+
+        // Get the proposal id from the logs
+        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+
+        let closing = HandleMsg::Close { proposal_id };
+
+        // Close expired works
+        let env = mock_env_height(1234567);
+        let res = handle(
+            deps.as_mut(),
+            env,
+            mock_info(SOMEBODY, &[]),
+            closing.clone(),
+        )
+        .unwrap();
+
+        // Verify
+        assert_eq!(
+            res,
+            HandleResponse {
+                messages: vec![],
+                attributes: vec![
+                    attr("action", "close"),
+                    attr("sender", SOMEBODY),
+                    attr("proposal_id", proposal_id),
+                ],
+                data: None,
+            }
+        );
+
+        // Trying to close it again fails
+        let res = handle(deps.as_mut(), mock_env(), info, closing);
+
+        // Verify
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            ContractError::WrongCloseStatus {} => {}
+            e => panic!("unexpected error: {}", e),
+        }
+    }
+}

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -90,7 +90,7 @@ pub fn handle_propose(
 
     let vote_power = cfg
         .group
-        .is_member(&deps.querier, raw_sender)?
+        .is_member(&deps.querier, &raw_sender)?
         .ok_or_else(|| ContractError::Unauthorized {})?;
 
     // max expires also used as default
@@ -154,7 +154,7 @@ pub fn handle_vote(
 
     let vote_power = cfg
         .group
-        .is_member(&deps.querier, raw_sender)?
+        .is_member(&deps.querier, &raw_sender)?
         .ok_or_else(|| ContractError::Unauthorized {})?;
 
     // ensure proposal exists and can be voted on
@@ -407,7 +407,7 @@ fn query_voter(deps: Deps, voter: HumanAddr) -> StdResult<VoterResponse> {
     let voter_raw = deps.api.canonical_address(&voter)?;
     let weight = cfg
         .group
-        .is_member(&deps.querier, voter_raw)?
+        .is_member(&deps.querier, &voter_raw)?
         .unwrap_or_default();
 
     Ok(VoterResponse {

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -618,8 +618,6 @@ mod tests {
         );
     }
 
-    // TODO: query() tests
-
     #[test]
     fn test_propose_works() {
         let mut app = mock_app();

--- a/contracts/cw3-flex-multisig/src/error.rs
+++ b/contracts/cw3-flex-multisig/src/error.rs
@@ -1,0 +1,41 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Required weight cannot be zero")]
+    ZeroWeight {},
+
+    #[error("Not possible to reach required (passing) weight")]
+    UnreachableWeight {},
+
+    #[error("No voters")]
+    NoVoters {},
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Proposal is not open")]
+    NotOpen {},
+
+    #[error("Proposal voting period has expired")]
+    Expired {},
+
+    #[error("Proposal must expire before you can close it")]
+    NotExpired {},
+
+    #[error("Wrong expiration option")]
+    WrongExpiration {},
+
+    #[error("Already voted on this proposal")]
+    AlreadyVoted {},
+
+    #[error("Proposal must have passed and not yet been executed")]
+    WrongExecuteStatus {},
+
+    #[error("Cannot close completed or passed proposals")]
+    WrongCloseStatus {},
+}

--- a/contracts/cw3-flex-multisig/src/error.rs
+++ b/contracts/cw3-flex-multisig/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::StdError;
+use cosmwasm_std::{HumanAddr, StdError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -12,8 +12,8 @@ pub enum ContractError {
     #[error("Not possible to reach required (passing) weight")]
     UnreachableWeight {},
 
-    #[error("Group contract invalid address")]
-    InvalidGroup {},
+    #[error("Group contract invalid address '{addr}'")]
+    InvalidGroup { addr: HumanAddr },
 
     #[error("Unauthorized")]
     Unauthorized {},

--- a/contracts/cw3-flex-multisig/src/error.rs
+++ b/contracts/cw3-flex-multisig/src/error.rs
@@ -12,8 +12,8 @@ pub enum ContractError {
     #[error("Not possible to reach required (passing) weight")]
     UnreachableWeight {},
 
-    #[error("No voters")]
-    NoVoters {},
+    #[error("Group contract invalid address")]
+    InvalidGroup {},
 
     #[error("Unauthorized")]
     Unauthorized {},

--- a/contracts/cw3-flex-multisig/src/lib.rs
+++ b/contracts/cw3-flex-multisig/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+#[cfg(all(target_arch = "wasm32", not(feature = "library")))]
+cosmwasm_std::create_entry_points!(contract);

--- a/contracts/cw3-flex-multisig/src/msg.rs
+++ b/contracts/cw3-flex-multisig/src/msg.rs
@@ -8,7 +8,7 @@ use cw3::Vote;
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InitMsg {
     // this is the group contract that contains the member list
-    pub group: HumanAddr,
+    pub group_addr: HumanAddr,
     pub required_weight: u64,
     pub max_voting_period: Duration,
 }

--- a/contracts/cw3-flex-multisig/src/msg.rs
+++ b/contracts/cw3-flex-multisig/src/msg.rs
@@ -7,15 +7,10 @@ use cw3::Vote;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InitMsg {
-    pub voters: Vec<Voter>,
+    // this is the group contract that contains the member list
+    pub group: HumanAddr,
     pub required_weight: u64,
     pub max_voting_period: Duration,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct Voter {
-    pub addr: HumanAddr,
-    pub weight: u64,
 }
 
 // TODO: add some T variants? Maybe good enough as fixed Empty for now

--- a/contracts/cw3-flex-multisig/src/msg.rs
+++ b/contracts/cw3-flex-multisig/src/msg.rs
@@ -1,0 +1,78 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{CosmosMsg, Empty, HumanAddr};
+use cw0::{Duration, Expiration};
+use cw3::Vote;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct InitMsg {
+    pub voters: Vec<Voter>,
+    pub required_weight: u64,
+    pub max_voting_period: Duration,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct Voter {
+    pub addr: HumanAddr,
+    pub weight: u64,
+}
+
+// TODO: add some T variants? Maybe good enough as fixed Empty for now
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HandleMsg {
+    Propose {
+        title: String,
+        description: String,
+        msgs: Vec<CosmosMsg<Empty>>,
+        // note: we ignore API-spec'd earliest if passed, always opens immediately
+        latest: Option<Expiration>,
+    },
+    Vote {
+        proposal_id: u64,
+        vote: Vote,
+    },
+    Execute {
+        proposal_id: u64,
+    },
+    Close {
+        proposal_id: u64,
+    },
+}
+
+// TODO: add a custom query to return the voter list (all potential voters)
+// We can also add this as a cw3 extension
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    /// Return ThresholdResponse
+    Threshold {},
+    /// Returns ProposalResponse
+    Proposal { proposal_id: u64 },
+    /// Returns ProposalListResponse
+    ListProposals {
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+    /// Returns ProposalListResponse
+    ReverseProposals {
+        start_before: Option<u64>,
+        limit: Option<u32>,
+    },
+    /// Returns VoteResponse
+    Vote { proposal_id: u64, voter: HumanAddr },
+    /// Returns VoteListResponse
+    ListVotes {
+        proposal_id: u64,
+        start_after: Option<HumanAddr>,
+        limit: Option<u32>,
+    },
+    /// Returns VoterResponse
+    Voter { address: HumanAddr },
+    /// Returns VoterListResponse
+    ListVoters {
+        start_after: Option<HumanAddr>,
+        limit: Option<u32>,
+    },
+}

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -6,13 +6,15 @@ use cosmwasm_std::{BlockInfo, CosmosMsg, Empty, StdError, StdResult, Storage};
 
 use cw0::{Duration, Expiration};
 use cw3::{Status, Vote};
+use cw4::Cw4Contract;
 use cw_storage_plus::{Item, Map, U64Key};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Config {
     pub required_weight: u64,
-    pub total_weight: u64,
     pub max_voting_period: Duration,
+    // Total weight and voters are queried from this contract
+    pub group: Cw4Contract,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -58,7 +60,6 @@ pub const CONFIG: Item<Config> = Item::new(b"config");
 pub const PROPOSAL_COUNT: Item<u64> = Item::new(b"proposal_count");
 
 // multiple-item maps
-pub const VOTERS: Map<&[u8], u64> = Map::new(b"voters");
 pub const PROPOSALS: Map<U64Key, Proposal> = Map::new(b"proposals");
 pub const BALLOTS: Map<(U64Key, &[u8]), Ballot> = Map::new(b"votes");
 

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -14,7 +14,7 @@ pub struct Config {
     pub required_weight: u64,
     pub max_voting_period: Duration,
     // Total weight and voters are queried from this contract
-    pub group: Cw4Contract,
+    pub group_addr: Cw4Contract,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -1,0 +1,78 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+
+use cosmwasm_std::{BlockInfo, CosmosMsg, Empty, StdError, StdResult, Storage};
+
+use cw0::{Duration, Expiration};
+use cw3::{Status, Vote};
+use cw_storage_plus::{Item, Map, U64Key};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct Config {
+    pub required_weight: u64,
+    pub total_weight: u64,
+    pub max_voting_period: Duration,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct Proposal {
+    pub title: String,
+    pub description: String,
+    pub expires: Expiration,
+    pub msgs: Vec<CosmosMsg<Empty>>,
+    pub status: Status,
+    /// how many votes have already said yes
+    pub yes_weight: u64,
+    /// how many votes needed to pass
+    pub required_weight: u64,
+}
+
+impl Proposal {
+    /// TODO: we should get the current BlockInfo and then we can determine this a bit better
+    pub fn current_status(&self, block: &BlockInfo) -> Status {
+        let mut status = self.status;
+
+        // if open, check if voting is passed or timed out
+        if status == Status::Open && self.yes_weight >= self.required_weight {
+            status = Status::Passed;
+        }
+        if status == Status::Open && self.expires.is_expired(block) {
+            status = Status::Rejected;
+        }
+
+        status
+    }
+}
+
+// we cast a ballot with our chosen vote and a given weight
+// stored under the key that voted
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct Ballot {
+    pub weight: u64,
+    pub vote: Vote,
+}
+
+// unique items
+pub const CONFIG: Item<Config> = Item::new(b"config");
+pub const PROPOSAL_COUNT: Item<u64> = Item::new(b"proposal_count");
+
+// multiple-item maps
+pub const VOTERS: Map<&[u8], u64> = Map::new(b"voters");
+pub const PROPOSALS: Map<U64Key, Proposal> = Map::new(b"proposals");
+pub const BALLOTS: Map<(U64Key, &[u8]), Ballot> = Map::new(b"votes");
+
+pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
+    let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;
+    PROPOSAL_COUNT.save(store, &id)?;
+    Ok(id)
+}
+
+pub fn parse_id(data: &[u8]) -> StdResult<u64> {
+    match data[0..8].try_into() {
+        Ok(bytes) => Ok(u64::from_be_bytes(bytes)),
+        Err(_) => Err(StdError::generic_err(
+            "Corrupted data found. 8 byte expected.",
+        )),
+    }
+}

--- a/packages/cw4/src/helpers.rs
+++ b/packages/cw4/src/helpers.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
     from_slice, to_binary, to_vec, Api, Binary, CanonicalAddr, ContractResult, CosmosMsg, Empty,
-    HumanAddr, Querier, QuerierWrapper, QueryRequest, StdError, StdResult, SystemResult, WasmMsg,
-    WasmQuery,
+    HumanAddr, QuerierWrapper, QueryRequest, StdError, StdResult, SystemResult, WasmMsg, WasmQuery,
 };
 
 use crate::msg::Cw4HandleMsg;
@@ -67,26 +66,26 @@ impl Cw4Contract {
     }
 
     /// Read the admin
-    pub fn admin<Q: Querier>(&self, querier: &Q) -> StdResult<Option<HumanAddr>> {
+    pub fn admin(&self, querier: &QuerierWrapper) -> StdResult<Option<HumanAddr>> {
         let query = self.encode_smart_query(Cw4QueryMsg::Admin {})?;
-        let res: AdminResponse = QuerierWrapper::new(querier).query(&query)?;
+        let res: AdminResponse = querier.query(&query)?;
         Ok(res.admin)
     }
 
     /// Read the total weight
-    pub fn total_weight<Q: Querier>(&self, querier: &Q) -> StdResult<u64> {
+    pub fn total_weight(&self, querier: &QuerierWrapper) -> StdResult<u64> {
         let query = self.encode_raw_query(TOTAL_KEY)?;
-        QuerierWrapper::new(querier).query(&query)
+        querier.query(&query)
     }
 
     // TODO: implement with raw queries
     /// Check if this address is a member, and if so, with which weight
-    pub fn is_member<Q: Querier, T: Into<CanonicalAddr>>(
+    pub fn is_member(
         &self,
-        querier: &Q,
-        addr: T,
+        querier: &QuerierWrapper,
+        addr: &CanonicalAddr,
     ) -> StdResult<Option<u64>> {
-        let path = member_key(&addr.into());
+        let path = member_key(addr.as_slice());
         let query = self.encode_raw_query(path)?;
 
         // We have to copy the logic of Querier.query to handle the empty case, and not
@@ -112,14 +111,14 @@ impl Cw4Contract {
         }
     }
 
-    pub fn list_members<Q: Querier>(
+    pub fn list_members(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         start_after: Option<HumanAddr>,
         limit: Option<u32>,
     ) -> StdResult<Vec<Member>> {
         let query = self.encode_smart_query(Cw4QueryMsg::ListMembers { start_after, limit })?;
-        let res: MemberListResponse = QuerierWrapper::new(querier).query(&query)?;
+        let res: MemberListResponse = querier.query(&query)?;
         Ok(res.members)
     }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,7 +8,7 @@ ALL_PACKAGES="cw1 cw2 cw3 cw4 cw20 cw721"
 
 # these are imported by other contracts
 BASE_CONTRACTS="cw1-whitelist cw4-group cw20-base cw721-base"
-ALL_CONTRACTS="cw1-subkeys cw3-fixed-multisig cw20-atomic-swap cw20-escrow cw20-staking"
+ALL_CONTRACTS="cw1-subkeys cw3-fixed-multisig cw3-flex-multisig cw20-atomic-swap cw20-escrow cw20-staking"
 
 SLEEP_TIME=30
 


### PR DESCRIPTION
Closes #80

This no longer stores the members locally (in contract), but uses raw queries to read them from an associated group.

The code changes were relatively small. The tests must be completely re-written to use multi-test. Notably, this was even a couple lines of code shorter after the refactor. And that using multiple contracts in a much more complicated test harness.

In the end, this works the same as the `cw3-fixed-multisig`, but opens the door for all the other mutlisig tickets

The first two commits are quite huge and just make a clone of cw3-fixed-multisig as a new contract. To review, you can just check all commits after the first two, and make sure to expand `contract.rs`, which is where most of the changes are: https://github.com/CosmWasm/cosmwasm-plus/pull/150/files/2a70c8baea7dfe534f136cff1bfa20b3485128fa..HEAD
