### PR TITLE
Close proposal on membership change

### DIFF
--- a/contracts/cw3-flex-multisig/README.md
+++ b/contracts/cw3-flex-multisig/README.md
@@ -33,7 +33,7 @@ to modify it's own group, do the following in multiple transactions:
 
   * init cw4-group, with your personal key as admin
   * init a multisig pointing to the group
-  * `AddHook{multisig}` on the group contract 
+  * `AddHook{multisig}` on the group contract
   * `UpdateAdmin{multisig}` on the group contract
 
 This is the current practice to create such circular dependencies,

--- a/contracts/cw3-flex-multisig/README.md
+++ b/contracts/cw3-flex-multisig/README.md
@@ -33,7 +33,7 @@ to modify it's own group, do the following in multiple transactions:
 
   * init cw4-group, with your personal key as admin
   * init a multisig pointing to the group
-  * TODO: `AddHook{multisig}` on the group contract 
+  * `AddHook{multisig}` on the group contract 
   * `UpdateAdmin{multisig}` on the group contract
 
 This is the current practice to create such circular dependencies,

--- a/contracts/cw3-flex-multisig/schema/handle_msg.json
+++ b/contracts/cw3-flex-multisig/schema/handle_msg.json
@@ -108,6 +108,18 @@
           }
         }
       }
+    },
+    {
+      "description": "handle update hook messages from the group contract",
+      "type": "object",
+      "required": [
+        "member_changed_hook"
+      ],
+      "properties": {
+        "member_changed_hook": {
+          "$ref": "#/definitions/MemberChangedHookMsg"
+        }
+      }
     }
   ],
   "definitions": {
@@ -263,6 +275,49 @@
     },
     "HumanAddr": {
       "type": "string"
+    },
+    "MemberChangedHookMsg": {
+      "description": "MemberChangedHookMsg should be de/serialized under `MemberChangedHook()` variant in a HandleMsg",
+      "type": "object",
+      "required": [
+        "diffs"
+      ],
+      "properties": {
+        "diffs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MemberDiff"
+          }
+        }
+      }
+    },
+    "MemberDiff": {
+      "description": "MemberDiff shows the old and new states for a given cw4 member They cannot both be None. old = None, new = Some -> Insert old = Some, new = Some -> Update old = Some, new = None -> Delete",
+      "type": "object",
+      "required": [
+        "addr"
+      ],
+      "properties": {
+        "addr": {
+          "$ref": "#/definitions/HumanAddr"
+        },
+        "new_weight": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "old_weight": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     },
     "StakingMsg": {
       "anyOf": [

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -1140,6 +1140,15 @@ mod tests {
             .execute_contract(VOTER4, &flex_addr, &yes_vote, &[])
             .unwrap_err();
         assert_eq!(err, ContractError::NotOpen {}.to_string());
+
+        // extra: ensure no one else can call the hook
+        let hook_hack = HandleMsg::MemberChangedHook(MemberChangedHookMsg {
+            diffs: vec![MemberDiff::new(VOTER1, Some(1), None)],
+        });
+        let err = app
+            .execute_contract(VOTER2, &flex_addr, &hook_hack, &[])
+            .unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {}.to_string());
     }
 
     // TODO: ensure no one else can call the hook

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -1087,11 +1087,11 @@ mod tests {
         let query_voter = QueryMsg::Voter {
             address: VOTER3.into(),
         };
-        let power: VoterResponse = app
+        let power: VoterInfo = app
             .wrap()
             .query_wasm_smart(&flex_addr, &query_voter)
             .unwrap();
-        assert_eq!(power.weight, 3);
+        assert_eq!(power.weight, Some(3));
 
         // Pass and execute first proposal
         let yes_vote = HandleMsg::Vote {
@@ -1107,11 +1107,11 @@ mod tests {
             .unwrap();
 
         // check membership changed properly
-        let power: VoterResponse = app
+        let power: VoterInfo = app
             .wrap()
             .query_wasm_smart(&flex_addr, &query_voter)
             .unwrap();
-        assert_eq!(power.weight, 0); // FIXME: this should become None in a future PR
+        assert_eq!(power.weight, None);
 
         // first proposal executed, second closed
         let query_prop_1 = QueryMsg::Proposal {

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -698,11 +698,12 @@ mod tests {
         );
 
         let proposal = pay_somebody_proposal(&flex_addr);
+        // Only voters can propose
         let res = app.execute_contract(SOMEBODY, &flex_addr, &proposal, &[]);
         assert_eq!(res.unwrap_err(), ContractError::Unauthorized {}.to_string());
 
         // Wrong expiration option fails
-        let msgs = match pay_somebody_proposal(&flex_addr) {
+        let msgs = match proposal.clone() {
             HandleMsg::Propose { msgs, .. } => msgs,
             _ => panic!("Wrong variant"),
         };

--- a/contracts/cw3-flex-multisig/src/msg.rs
+++ b/contracts/cw3-flex-multisig/src/msg.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{CosmosMsg, Empty, HumanAddr};
 use cw0::{Duration, Expiration};
 use cw3::Vote;
+use cw4::MemberChangedHookMsg;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InitMsg {
@@ -34,6 +35,8 @@ pub enum HandleMsg {
     Close {
         proposal_id: u64,
     },
+    /// handle update hook messages from the group contract
+    MemberChangedHook(MemberChangedHookMsg),
 }
 
 // TODO: add a custom query to return the voter list (all potential voters)

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -91,15 +91,15 @@ impl<'a> IndexList<Proposal> for ProposalIndexes<'a> {
 }
 
 /// Returns a value that can be used as a secondary index key in the proposals map
-pub fn status_index(status: &Status) -> Vec<u8> {
-    vec![*status as u8]
+pub fn status_index(status: Status) -> Vec<u8> {
+    vec![status as u8]
 }
 
 // secondary indexes on state for PROPOSALS to find all open proposals efficiently
 pub fn proposals<'a>() -> IndexedMap<'a, U64Key, Proposal, ProposalIndexes<'a>> {
     let indexes = ProposalIndexes {
         status: MultiIndex::new(
-            |p| status_index(&p.status),
+            |p| status_index(p.status),
             b"proposals",
             b"proposals__status",
         ),

--- a/packages/cw3/src/query.rs
+++ b/packages/cw3/src/query.rs
@@ -96,17 +96,18 @@ where
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "lowercase")]
+#[repr(u8)]
 pub enum Status {
     /// proposal was created, but voting has not yet begun for whatever reason
-    Pending,
+    Pending = 1,
     /// you can vote on this
-    Open,
+    Open = 2,
     /// voting is over and it did not pass
-    Rejected,
+    Rejected = 3,
     /// voting is over and it did pass, but has not yet executed
-    Passed,
+    Passed = 4,
     /// voting is over it passed, and the proposal was executed
-    Executed,
+    Executed = 5,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]


### PR DESCRIPTION
Based on #156 (merge that first)
Addresses #141 (just the simple solution to show hooks, need a second PR to close issue)

- [x] Register callback hooks in all tests
- [x] Implement member changed hook handler
- [x] Test proper handling of simple solution: *If an "update group" event comes in while there is an open proposal, force close all open proposals*
- [x] Improve implementation efficiency (don't iterate over all proposals ever made to find open proposals)

We just need to optimize the query (add secondary index to proposals map), otherwise this is ready to review