### PR TITLE
cw3-flex-multisig uses voting power from a snapshot of the block the proposal opened

### DIFF
--- a/contracts/cw3-flex-multisig/schema/handle_msg.json
+++ b/contracts/cw3-flex-multisig/schema/handle_msg.json
@@ -295,13 +295,13 @@
       "description": "MemberDiff shows the old and new states for a given cw4 member They cannot both be None. old = None, new = Some -> Insert old = Some, new = Some -> Update old = Some, new = None -> Delete",
       "type": "object",
       "required": [
-        "addr"
+        "key"
       ],
       "properties": {
-        "addr": {
+        "key": {
           "$ref": "#/definitions/HumanAddr"
         },
-        "new_weight": {
+        "new": {
           "type": [
             "integer",
             "null"
@@ -309,7 +309,7 @@
           "format": "uint64",
           "minimum": 0.0
         },
-        "old_weight": {
+        "old": {
           "type": [
             "integer",
             "null"

--- a/contracts/cw3-flex-multisig/src/lib.rs
+++ b/contracts/cw3-flex-multisig/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod contract;
 mod error;
 pub mod msg;
+mod snapshot;
 pub mod state;
 
 #[cfg(all(target_arch = "wasm32", not(feature = "library")))]

--- a/contracts/cw3-flex-multisig/src/snapshot.rs
+++ b/contracts/cw3-flex-multisig/src/snapshot.rs
@@ -31,15 +31,13 @@ pub fn snapshot_diff(
     current_height: u64,
     latest_snapshot_height: u64,
 ) -> StdResult<()> {
-    let raw_addr = deps.api.canonical_address(&diff.addr)?;
+    let raw_addr = deps.api.canonical_address(&diff.key)?;
     match load_snapshot(deps.storage, &raw_addr, latest_snapshot_height)? {
         Some(_) => Ok(()),
         None => SNAPSHOTS.save(
             deps.storage,
             (&raw_addr, current_height.into()),
-            &VoterInfo {
-                weight: diff.old_weight,
-            },
+            &VoterInfo { weight: diff.old },
         ),
     }
 }

--- a/contracts/cw3-flex-multisig/src/snapshot.rs
+++ b/contracts/cw3-flex-multisig/src/snapshot.rs
@@ -3,7 +3,7 @@ use cw3::VoterInfo;
 use cw4::{Cw4Contract, MemberDiff};
 use cw_storage_plus::{Bound, Map, U64Key};
 
-/// SNAPSHOTS pk: (HUmanAddr, height) -> get the weight
+/// SNAPSHOTS pk: (HumanAddr, height) -> get the weight
 /// Use VoterInfo, so None (no data) is different than VoterInfo{weight: None} (record it was removed)
 pub const SNAPSHOTS: Map<(&[u8], U64Key), VoterInfo> = Map::new(b"snapshots");
 
@@ -43,7 +43,7 @@ pub fn snapshot_diff(
 }
 
 /// this will look for the first snapshot of the given address >= given height
-/// if none, there is no snapshot since that time, and the group query will give the current status
+/// If None, there is no snapshot since that time.
 fn load_snapshot(
     storage: &dyn Storage,
     addr: &CanonicalAddr,

--- a/contracts/cw3-flex-multisig/src/snapshot.rs
+++ b/contracts/cw3-flex-multisig/src/snapshot.rs
@@ -1,0 +1,65 @@
+use cosmwasm_std::{CanonicalAddr, Deps, DepsMut, HumanAddr, Order, StdResult, Storage};
+use cw3::VoterInfo;
+use cw4::{Cw4Contract, MemberDiff};
+use cw_storage_plus::{Bound, Map, U64Key};
+
+/// SNAPSHOTS pk: (HUmanAddr, height) -> get the weight
+/// Use VoterInfo, so None (no data) is different than VoterInfo{weight: None} (record it was removed)
+pub const SNAPSHOTS: Map<(&[u8], U64Key), VoterInfo> = Map::new(b"snapshots");
+
+/// load the weight from the snapshot - that is, first change >= height,
+/// or query the current contract state otherwise
+pub fn snapshoted_weight(
+    deps: Deps,
+    addr: &HumanAddr,
+    height: u64,
+    group: &Cw4Contract,
+) -> StdResult<Option<u64>> {
+    let raw_addr = deps.api.canonical_address(addr)?;
+
+    let snapshot = load_snapshot(deps.storage, &raw_addr, height)?;
+    match snapshot {
+        // use snapshot if available
+        Some(info) => Ok(info.weight),
+        // otherwise load from the group
+        None => group.is_member(&deps.querier, &raw_addr),
+    }
+}
+
+/// saves this diff only if no updates have been saved since the latest snapshot
+pub fn snapshot_diff(
+    deps: DepsMut,
+    diff: MemberDiff,
+    current_height: u64,
+    latest_snapshot_height: u64,
+) -> StdResult<()> {
+    let raw_addr = deps.api.canonical_address(&diff.addr)?;
+    match load_snapshot(deps.storage, &raw_addr, latest_snapshot_height)? {
+        Some(_) => Ok(()),
+        None => SNAPSHOTS.save(
+            deps.storage,
+            (&raw_addr, current_height.into()),
+            &VoterInfo {
+                weight: diff.old_weight,
+            },
+        ),
+    }
+}
+
+/// this will look for the first snapshot of the given address >= given height
+/// if none, there is no snapshot since that time, and the group query will give the current status
+fn load_snapshot(
+    storage: &dyn Storage,
+    addr: &CanonicalAddr,
+    height: u64,
+) -> StdResult<Option<VoterInfo>> {
+    let start = Bound::inclusive(U64Key::new(height));
+    let first = SNAPSHOTS
+        .prefix(&addr)
+        .range(storage, Some(start), None, Order::Ascending)
+        .next();
+    match first {
+        None => Ok(None),
+        Some(r) => r.map(|(_, v)| Some(v)),
+    }
+}

--- a/contracts/cw3-flex-multisig/src/snapshot.rs
+++ b/contracts/cw3-flex-multisig/src/snapshot.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{CanonicalAddr, Deps, DepsMut, HumanAddr, Order, StdResult, Storage};
+use cosmwasm_std::{CanonicalAddr, Deps, DepsMut, Order, StdResult, Storage};
 use cw3::VoterInfo;
 use cw4::{Cw4Contract, MemberDiff};
 use cw_storage_plus::{Bound, Map, U64Key};
@@ -11,18 +11,16 @@ pub const SNAPSHOTS: Map<(&[u8], U64Key), VoterInfo> = Map::new(b"snapshots");
 /// or query the current contract state otherwise
 pub fn snapshoted_weight(
     deps: Deps,
-    addr: &HumanAddr,
+    addr: &CanonicalAddr,
     height: u64,
     group: &Cw4Contract,
 ) -> StdResult<Option<u64>> {
-    let raw_addr = deps.api.canonical_address(addr)?;
-
-    let snapshot = load_snapshot(deps.storage, &raw_addr, height)?;
+    let snapshot = load_snapshot(deps.storage, &addr, height)?;
     match snapshot {
         // use snapshot if available
         Some(info) => Ok(info.weight),
         // otherwise load from the group
-        None => group.is_member(&deps.querier, &raw_addr),
+        None => group.is_member(&deps.querier, &addr),
     }
 }
 

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -21,6 +21,7 @@ pub struct Config {
 pub struct Proposal {
     pub title: String,
     pub description: String,
+    pub start_height: u64,
     pub expires: Expiration,
     pub msgs: Vec<CosmosMsg<Empty>>,
     pub status: Status,

--- a/packages/cw4/schema/member_changed_hook_msg.json
+++ b/packages/cw4/schema/member_changed_hook_msg.json
@@ -22,13 +22,13 @@
       "description": "MemberDiff shows the old and new states for a given cw4 member They cannot both be None. old = None, new = Some -> Insert old = Some, new = Some -> Update old = Some, new = None -> Delete",
       "type": "object",
       "required": [
-        "addr"
+        "key"
       ],
       "properties": {
-        "addr": {
+        "key": {
           "$ref": "#/definitions/HumanAddr"
         },
-        "new_weight": {
+        "new": {
           "type": [
             "integer",
             "null"
@@ -36,7 +36,7 @@
           "format": "uint64",
           "minimum": 0.0
         },
-        "old_weight": {
+        "old": {
           "type": [
             "integer",
             "null"

--- a/packages/cw4/src/hook.rs
+++ b/packages/cw4/src/hook.rs
@@ -17,9 +17,9 @@ pub struct MemberChangedHookMsg {
 /// old = Some, new = None -> Delete
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct MemberDiff {
-    pub addr: HumanAddr,
-    pub old_weight: Option<u64>,
-    pub new_weight: Option<u64>,
+    pub key: HumanAddr,
+    pub old: Option<u64>,
+    pub new: Option<u64>,
 }
 
 impl MemberDiff {
@@ -29,9 +29,9 @@ impl MemberDiff {
         new_weight: Option<u64>,
     ) -> Self {
         MemberDiff {
-            addr: addr.into(),
-            old_weight,
-            new_weight,
+            key: addr.into(),
+            old: old_weight,
+            new: new_weight,
         }
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -197,6 +197,12 @@ impl<T: Endian> From<PkOwned> for IntKey<T> {
     }
 }
 
+impl<T: Endian> Into<Vec<u8>> for IntKey<T> {
+    fn into(self) -> Vec<u8> {
+        self.wrapped.0
+    }
+}
+
 impl<T: Endian> AsRef<PkOwned> for IntKey<T> {
     fn as_ref(&self) -> &PkOwned {
         &self.wrapped

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -19,4 +19,4 @@ pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::{Bound, Prefix};
+pub use prefix::{range_with_prefix, Bound, Prefix};

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -93,7 +93,7 @@ where
     }
 }
 
-pub(crate) fn range_with_prefix<'a>(
+pub fn range_with_prefix<'a>(
     storage: &'a dyn Storage,
     namespace: &[u8],
     start: Option<Bound>,


### PR DESCRIPTION
Closes #141 

Uses the preferred "complex" solution. We no longer close open proposals when the group changes, but handle it gracefully

*Count all votes with state at beginning of voting period*

- The total weight needed to pass is fixed at the beginning and never changes
- If a member is updated and they haven't voted yet, record the previous weight (the value at the beginning of the proposal) in some local cache inside `cw3-flex-multisig`. When the member votes, the weight there overrides the current weight in the group. 

We do this with max 1 write per updated weight, only if this was the first time it has changed since the most recent proposal. -> O(diffs), regardless of how many proposals there are.

Future improvement: We currently iterate over all open proposals to find the latest start height. With a clever compound secondary index, we could do this with one read. 

TODO: 

- [x] Rename MemberDiff fields (old, new)
- [x] Test voting on second proposal doesn't use snapshot
- [x] Test complex case
- [x] Improve performance