### PR TITLE
Fix macro test / remove clippy directive

### DIFF
--- a/packages/storage-plus/src/snapshot.rs
+++ b/packages/storage-plus/src/snapshot.rs
@@ -269,7 +269,6 @@ pub struct SnapshotNamespaces<'a> {
 #[macro_export]
 macro_rules! snapshot_names {
     ($var:expr) => {
-        #[allow(clippy::string_lit_as_bytes)]
         SnapshotNamespaces {
             pk: $var.as_bytes(),
             checkpoints: concat!($var, "__checkpoints").as_bytes(),
@@ -285,15 +284,10 @@ mod tests {
 
     #[test]
     fn namespace_macro() {
-        let check = |names: SnapshotNamespaces| {
-            assert_eq!(names.pk, b"demo");
-            assert_eq!(names.checkpoints, b"demo__checkpoints");
-            assert_eq!(names.changelog, b"demo__changelog");
-        };
-        // FIXME: we have to do this weird way due to the clippy allow statement
-        check(snapshot_names!("demo"));
-        // ex. this line fails to compile
-        // let names = snapshot_names!("demo");
+        let names = snapshot_names!("demo");
+        assert_eq!(names.pk, b"demo");
+        assert_eq!(names.checkpoints, b"demo__checkpoints");
+        assert_eq!(names.changelog, b"demo__changelog");
     }
 
     type TestMap = SnapshotMap<'static, &'static [u8], u64>;


### PR DESCRIPTION
This works for me locally. Using the clippy directive inside the macro makes the test error with some "experimental feature" msg.
Removing the clippy directive doesn't seem to affect anything... plus, original test work.

Let's see if it passes the CI tests.