### PR TITLE
Fix namespace macro test

### DIFF
--- a/contracts/cw4-group/src/state.rs
+++ b/contracts/cw4-group/src/state.rs
@@ -1,13 +1,15 @@
 use cosmwasm_std::{CanonicalAddr, HumanAddr};
 use cw4::TOTAL_KEY;
-use cw_storage_plus::{snapshot_names, Item, SnapshotMap, SnapshotNamespaces, Strategy};
+use cw_storage_plus::{Item, SnapshotMap, SnapshotNamespaces, Strategy};
 
 pub const ADMIN: Item<Option<CanonicalAddr>> = Item::new(b"admin");
 pub const TOTAL: Item<u64> = Item::new(TOTAL_KEY);
 
 // Note: this must be same as cw4::MEMBERS_KEY but macro needs literal, not const
-pub const MEMBERS: SnapshotMap<&[u8], u64> =
-    SnapshotMap::new(snapshot_names!("members"), Strategy::EveryBlock);
+pub const MEMBERS: SnapshotMap<&[u8], u64> = SnapshotMap::new(
+    SnapshotNamespaces::new(cw4::MEMBERS_KEY, cw4::MEMBERS_CHECK, cw4::MEMBERS_CHANGE),
+    Strategy::EveryBlock,
+);
 
 // store all hook addresses in one item. We cannot have many of them before the contract
 // becomes unusable

--- a/contracts/cw4-group/src/state.rs
+++ b/contracts/cw4-group/src/state.rs
@@ -8,8 +8,8 @@ pub const TOTAL: Item<u64> = Item::new(TOTAL_KEY);
 // Note: this must be same as cw4::MEMBERS_KEY but macro needs literal, not const
 pub const MEMBERS: SnapshotMap<&[u8], u64> = SnapshotMap::new(
     cw4::MEMBERS_KEY,
-    cw4::MEMBERS_CHECK,
-    cw4::MEMBERS_CHANGE,
+    cw4::MEMBERS_CHECKPOINTS,
+    cw4::MEMBERS_CHANGELOG,
     Strategy::EveryBlock,
 );
 

--- a/contracts/cw4-group/src/state.rs
+++ b/contracts/cw4-group/src/state.rs
@@ -1,13 +1,15 @@
 use cosmwasm_std::{CanonicalAddr, HumanAddr};
 use cw4::TOTAL_KEY;
-use cw_storage_plus::{Item, SnapshotMap, SnapshotNamespaces, Strategy};
+use cw_storage_plus::{Item, SnapshotMap, Strategy};
 
 pub const ADMIN: Item<Option<CanonicalAddr>> = Item::new(b"admin");
 pub const TOTAL: Item<u64> = Item::new(TOTAL_KEY);
 
 // Note: this must be same as cw4::MEMBERS_KEY but macro needs literal, not const
 pub const MEMBERS: SnapshotMap<&[u8], u64> = SnapshotMap::new(
-    SnapshotNamespaces::new(cw4::MEMBERS_KEY, cw4::MEMBERS_CHECK, cw4::MEMBERS_CHANGE),
+    cw4::MEMBERS_KEY,
+    cw4::MEMBERS_CHECK,
+    cw4::MEMBERS_CHANGE,
     Strategy::EveryBlock,
 );
 

--- a/packages/cw4/NOTICE
+++ b/packages/cw4/NOTICE
@@ -1,4 +1,4 @@
-CW3: A CosmWasm spec for on-chain multiSig/voting contracts
+CW4: A CosmWasm spec for groups
 Copyright (C) 2020 Confio OÜ
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/cw4/src/lib.rs
+++ b/packages/cw4/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::hook::{MemberChangedHookMsg, MemberDiff};
 pub use crate::msg::{Cw4HandleMsg, Cw4InitMsg, Member};
 pub use crate::query::{
     member_key, AdminResponse, Cw4QueryMsg, HooksResponse, MemberListResponse, MemberResponse,
-    TotalWeightResponse, MEMBERS_CHANGE, MEMBERS_CHECK, MEMBERS_KEY, TOTAL_KEY,
+    TotalWeightResponse, MEMBERS_CHANGELOG, MEMBERS_CHECKPOINTS, MEMBERS_KEY, TOTAL_KEY,
 };
 
 #[cfg(test)]

--- a/packages/cw4/src/lib.rs
+++ b/packages/cw4/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::hook::{MemberChangedHookMsg, MemberDiff};
 pub use crate::msg::{Cw4HandleMsg, Cw4InitMsg, Member};
 pub use crate::query::{
     member_key, AdminResponse, Cw4QueryMsg, HooksResponse, MemberListResponse, MemberResponse,
-    TotalWeightResponse, MEMBERS_KEY, TOTAL_KEY,
+    TotalWeightResponse, MEMBERS_CHANGE, MEMBERS_CHECK, MEMBERS_KEY, TOTAL_KEY,
 };
 
 #[cfg(test)]

--- a/packages/cw4/src/query.rs
+++ b/packages/cw4/src/query.rs
@@ -53,7 +53,9 @@ pub struct HooksResponse {
 
 /// TOTAL_KEY is meant for raw queries
 pub const TOTAL_KEY: &[u8] = b"total";
-pub const MEMBERS_KEY: &[u8] = b"members";
+pub const MEMBERS_KEY: &str = "members";
+pub const MEMBERS_CHECK: &str = "members__checkpoints";
+pub const MEMBERS_CHANGE: &str = "members__changelog";
 
 /// member_key is meant for raw queries for one member, given canonical address
 pub fn member_key(address: &[u8]) -> Vec<u8> {

--- a/packages/cw4/src/query.rs
+++ b/packages/cw4/src/query.rs
@@ -54,8 +54,8 @@ pub struct HooksResponse {
 /// TOTAL_KEY is meant for raw queries
 pub const TOTAL_KEY: &[u8] = b"total";
 pub const MEMBERS_KEY: &str = "members";
-pub const MEMBERS_CHECK: &str = "members__checkpoints";
-pub const MEMBERS_CHANGE: &str = "members__changelog";
+pub const MEMBERS_CHECKPOINTS: &str = "members__checkpoints";
+pub const MEMBERS_CHANGELOG: &str = "members__changelog";
 
 /// member_key is meant for raw queries for one member, given canonical address
 pub fn member_key(address: &[u8]) -> Vec<u8> {

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -22,4 +22,4 @@ pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Bound, Prefix};
 #[cfg(feature = "iterator")]
-pub use snapshot::{SnapshotMap, SnapshotNamespaces, Strategy};
+pub use snapshot::{SnapshotMap, Strategy};

--- a/packages/storage-plus/src/snapshot.rs
+++ b/packages/storage-plus/src/snapshot.rs
@@ -42,11 +42,16 @@ pub enum Strategy {
 
 impl<'a, K, T> SnapshotMap<'a, K, T> {
     /// Usage: SnapshotMap::new(snapshot_names!("foobar"), Strategy::EveryBlock)
-    pub const fn new(namespaces: SnapshotNamespaces<'a>, strategy: Strategy) -> Self {
+    pub const fn new(
+        pk: &'a str,
+        checkpoints: &'a str,
+        changelog: &'a str,
+        strategy: Strategy,
+    ) -> Self {
         SnapshotMap {
-            primary: Map::new(namespaces.pk),
-            checkpoints: Map::new(namespaces.checkpoints),
-            changelog: Map::new(namespaces.changelog),
+            primary: Map::new(pk.as_bytes()),
+            checkpoints: Map::new(checkpoints.as_bytes()),
+            changelog: Map::new(changelog.as_bytes()),
             strategy,
         }
     }
@@ -260,51 +265,24 @@ struct ChangeSet<T> {
     pub old: Option<T>,
 }
 
-pub struct SnapshotNamespaces<'a> {
-    pub pk: &'a [u8],
-    pub checkpoints: &'a [u8],
-    pub changelog: &'a [u8],
-}
-
-impl<'a> SnapshotNamespaces<'a> {
-    pub const fn new(
-        pk: &'static str,
-        checkpoints: &'static str,
-        changelog: &'static str,
-    ) -> SnapshotNamespaces<'a> {
-        SnapshotNamespaces {
-            pk: pk.as_bytes(),
-            checkpoints: checkpoints.as_bytes(),
-            changelog: changelog.as_bytes(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SnapshotNamespaces;
     use cosmwasm_std::testing::MockStorage;
 
-    #[test]
-    fn snapshot_names() {
-        let names = SnapshotNamespaces::new("demo", "demo__checkpoints", "demo__changelog");
-        assert_eq!(names.pk, b"demo");
-        assert_eq!(names.checkpoints, b"demo__checkpoints");
-        assert_eq!(names.changelog, b"demo__changelog");
-    }
-
     type TestMap = SnapshotMap<'static, &'static [u8], u64>;
-    const NEVER: TestMap = SnapshotMap::new(
-        SnapshotNamespaces::new("never", "never__check", "never__change"),
-        Strategy::Never,
-    );
+    const NEVER: TestMap =
+        SnapshotMap::new("never", "never__check", "never__change", Strategy::Never);
     const EVERY: TestMap = SnapshotMap::new(
-        SnapshotNamespaces::new("every", "every__check", "every__change"),
+        "every",
+        "every__check",
+        "every__change",
         Strategy::EveryBlock,
     );
     const SELECT: TestMap = SnapshotMap::new(
-        SnapshotNamespaces::new("select", "select__check", "select__change"),
+        "select",
+        "select__check",
+        "select__change",
         Strategy::Selected,
     );
 


### PR DESCRIPTION
"Fixing" the namespaces macro by removing it entirely, at the cost of two more (explicit) static strings.

Names can still be improved a little IMO, but I wanted to introduce as little changes as possible first.

- `SnapshotNamespaces` -> `SnapshotNames`?
- Maybe `SnapshotNamespaces` can be entirely removed (and `SnapshotMap::new()` takes the burden).
- `MEMBERS_CHECK` -> `MEMBERS_CHECKPOINTS`?
- `MEMBERS_CHANGE` -> `MEMBERS_CHANGELOG`?
- Using `&[u8]` instead of `&str` for consistency?

Your call, but I think this is simpler, and clearer. At the cost of being a little bit more verbose.