### PR TITLE
Replace byte slices by string slices in names and constructors

### DIFF
--- a/contracts/cw3-fixed-multisig/src/state.rs
+++ b/contracts/cw3-fixed-multisig/src/state.rs
@@ -54,13 +54,13 @@ pub struct Ballot {
 }
 
 // unique items
-pub const CONFIG: Item<Config> = Item::new(b"config");
-pub const PROPOSAL_COUNT: Item<u64> = Item::new(b"proposal_count");
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");
 
 // multiple-item maps
-pub const VOTERS: Map<&[u8], u64> = Map::new(b"voters");
-pub const PROPOSALS: Map<U64Key, Proposal> = Map::new(b"proposals");
-pub const BALLOTS: Map<(U64Key, &[u8]), Ballot> = Map::new(b"votes");
+pub const VOTERS: Map<&[u8], u64> = Map::new("voters");
+pub const PROPOSALS: Map<U64Key, Proposal> = Map::new("proposals");
+pub const BALLOTS: Map<(U64Key, &[u8]), Ballot> = Map::new("votes");
 
 pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -56,12 +56,12 @@ pub struct Ballot {
 }
 
 // unique items
-pub const CONFIG: Item<Config> = Item::new(b"config");
-pub const PROPOSAL_COUNT: Item<u64> = Item::new(b"proposal_count");
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");
 
 // multiple-item map
-pub const BALLOTS: Map<(U64Key, &[u8]), Ballot> = Map::new(b"votes");
-pub const PROPOSALS: Map<U64Key, Proposal> = Map::new(b"proposals");
+pub const BALLOTS: Map<(U64Key, &[u8]), Ballot> = Map::new("votes");
+pub const PROPOSALS: Map<U64Key, Proposal> = Map::new("proposals");
 
 pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -651,7 +651,7 @@ mod tests {
         do_init(deps.as_mut());
 
         // get total from raw key
-        let total_raw = deps.storage.get(TOTAL_KEY).unwrap();
+        let total_raw = deps.storage.get(TOTAL_KEY.as_bytes()).unwrap();
         let total: u64 = from_slice(&total_raw).unwrap();
         assert_eq!(17, total);
 

--- a/contracts/cw4-group/src/state.rs
+++ b/contracts/cw4-group/src/state.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{CanonicalAddr, HumanAddr};
 use cw4::TOTAL_KEY;
 use cw_storage_plus::{Item, SnapshotMap, Strategy};
 
-pub const ADMIN: Item<Option<CanonicalAddr>> = Item::new(b"admin");
+pub const ADMIN: Item<Option<CanonicalAddr>> = Item::new("admin");
 pub const TOTAL: Item<u64> = Item::new(TOTAL_KEY);
 
 // Note: this must be same as cw4::MEMBERS_KEY but macro needs literal, not const
@@ -15,4 +15,4 @@ pub const MEMBERS: SnapshotMap<&[u8], u64> = SnapshotMap::new(
 
 // store all hook addresses in one item. We cannot have many of them before the contract
 // becomes unusable
-pub const HOOKS: Item<Vec<HumanAddr>> = Item::new(b"hooks");
+pub const HOOKS: Item<Vec<HumanAddr>> = Item::new("hooks");

--- a/contracts/cw721-base/src/state.rs
+++ b/contracts/cw721-base/src/state.rs
@@ -28,12 +28,12 @@ pub struct Approval {
     pub expires: Expiration,
 }
 
-pub const CONTRACT_INFO: Item<ContractInfoResponse> = Item::new(b"nft_info");
-pub const MINTER: Item<CanonicalAddr> = Item::new(b"minter");
-pub const TOKEN_COUNT: Item<u64> = Item::new(b"num_tokens");
+pub const CONTRACT_INFO: Item<ContractInfoResponse> = Item::new("nft_info");
+pub const MINTER: Item<CanonicalAddr> = Item::new("minter");
+pub const TOKEN_COUNT: Item<u64> = Item::new("num_tokens");
 
-// pub const TOKENS: Map<&str, TokenInfo> = Map::new(b"tokens");
-pub const OPERATORS: Map<(&[u8], &[u8]), Expiration> = Map::new(b"operators");
+// pub const TOKENS: Map<&str, TokenInfo> = Map::new("tokens");
+pub const OPERATORS: Map<(&[u8], &[u8]), Expiration> = Map::new("operators");
 
 pub fn num_tokens(storage: &dyn Storage) -> StdResult<u64> {
     Ok(TOKEN_COUNT.may_load(storage)?.unwrap_or_default())
@@ -58,7 +58,7 @@ impl<'a> IndexList<TokenInfo> for TokenIndexes<'a> {
 
 pub fn tokens<'a>() -> IndexedMap<'a, &'a str, TokenInfo, TokenIndexes<'a>> {
     let indexes = TokenIndexes {
-        owner: MultiIndex::new(|d| d.owner.to_vec(), b"tokens", b"tokens__owner"),
+        owner: MultiIndex::new(|d| d.owner.to_vec(), "tokens", "tokens__owner"),
     };
-    IndexedMap::new(b"tokens", indexes)
+    IndexedMap::new("tokens", indexes)
 }

--- a/packages/cw2/src/lib.rs
+++ b/packages/cw2/src/lib.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
 };
 use cw_storage_plus::Item;
 
-pub const CONTRACT: Item<ContractVersion> = Item::new(b"contract_info");
+pub const CONTRACT: Item<ContractVersion> = Item::new("contract_info");
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct ContractVersion {

--- a/packages/cw4/src/helpers.rs
+++ b/packages/cw4/src/helpers.rs
@@ -94,7 +94,7 @@ impl Cw4Contract {
 
     /// Read the total weight
     pub fn total_weight(&self, querier: &QuerierWrapper) -> StdResult<u64> {
-        let query = self.encode_raw_query(TOTAL_KEY)?;
+        let query = self.encode_raw_query(TOTAL_KEY.as_bytes())?;
         querier.query(&query)
     }
 

--- a/packages/cw4/src/query.rs
+++ b/packages/cw4/src/query.rs
@@ -52,16 +52,18 @@ pub struct HooksResponse {
 }
 
 /// TOTAL_KEY is meant for raw queries
-pub const TOTAL_KEY: &[u8] = b"total";
+pub const TOTAL_KEY: &str = "total";
 pub const MEMBERS_KEY: &str = "members";
 pub const MEMBERS_CHECKPOINTS: &str = "members__checkpoints";
 pub const MEMBERS_CHANGELOG: &str = "members__changelog";
 
 /// member_key is meant for raw queries for one member, given canonical address
 pub fn member_key(address: &[u8]) -> Vec<u8> {
-    // length encoded members key (update if you change MEMBERS_KEY)
-    // inlined here to avoid storage-plus import
-    let mut key = b"\x00\x07members".to_vec();
+    // FIXME?: Inlined here to avoid storage-plus import
+    if MEMBERS_KEY.len() > 0xFF {
+        panic!("only supports member keys up to length 0xFF")
+    }
+    let mut key = [b"\x00", &[MEMBERS_KEY.len() as u8], MEMBERS_KEY.as_bytes()].concat();
     key.extend_from_slice(address);
     key
 }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -36,9 +36,9 @@ where
     I: IndexList<T>,
 {
     /// TODO: remove traits here and make this const fn new
-    pub fn new(pk_namespace: &'a [u8], indexes: I) -> Self {
+    pub fn new(pk_namespace: &'a str, indexes: I) -> Self {
         IndexedMap {
-            pk_namespace,
+            pk_namespace: pk_namespace.as_bytes(),
             primary: Map::new(pk_namespace),
             idx: indexes,
         }
@@ -183,10 +183,10 @@ mod test {
     // Can we make it easier to define this? (less wordy generic)
     fn build_map<'a>() -> IndexedMap<'a, &'a [u8], Data, DataIndexes<'a>> {
         let indexes = DataIndexes {
-            name: MultiIndex::new(|d| index_string(&d.name), b"data", b"data__name"),
-            age: UniqueIndex::new(|d| index_int(d.age), b"data__age"),
+            name: MultiIndex::new(|d| index_string(&d.name), "data", "data__name"),
+            age: UniqueIndex::new(|d| index_int(d.age), "data__age"),
         };
-        IndexedMap::new(b"data", indexes)
+        IndexedMap::new("data", indexes)
     }
 
     #[test]

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -48,7 +48,7 @@ pub struct MultiIndex<'a, T> {
 
 impl<'a, T> MultiIndex<'a, T> {
     // TODO: make this a const fn
-    pub fn new(idx_fn: fn(&T) -> Vec<u8>, pk_namespace: &'a [u8], idx_namespace: &'a [u8]) -> Self {
+    pub fn new(idx_fn: fn(&T) -> Vec<u8>, pk_namespace: &'a str, idx_namespace: &'a str) -> Self {
         MultiIndex {
             index: idx_fn,
             pk_map: Map::new(pk_namespace),
@@ -137,7 +137,7 @@ pub struct UniqueIndex<'a, T> {
 
 impl<'a, T> UniqueIndex<'a, T> {
     // TODO: make this a const fn
-    pub fn new(idx_fn: fn(&T) -> Vec<u8>, idx_namespace: &'a [u8]) -> Self {
+    pub fn new(idx_fn: fn(&T) -> Vec<u8>, idx_namespace: &'a str) -> Self {
         UniqueIndex {
             index: idx_fn,
             idx_map: Map::new(idx_namespace),

--- a/packages/storage-plus/src/item.rs
+++ b/packages/storage-plus/src/item.rs
@@ -17,9 +17,9 @@ pub struct Item<'a, T> {
 }
 
 impl<'a, T> Item<'a, T> {
-    pub const fn new(storage_key: &'a [u8]) -> Self {
+    pub const fn new(storage_key: &'a str) -> Self {
         Item {
-            storage_key,
+            storage_key: storage_key.as_bytes(),
             data_type: PhantomData,
         }
     }
@@ -88,7 +88,7 @@ mod test {
     }
 
     // note const constructor rather than 2 funcs with Singleton
-    const CONFIG: Item<Config> = Item::new(b"config");
+    const CONFIG: Item<Config> = Item::new("config");
 
     #[test]
     fn save_and_load() {
@@ -137,10 +137,10 @@ mod test {
         };
         CONFIG.save(&mut store, &cfg).unwrap();
 
-        let reader = Item::<Config>::new(b"config");
+        let reader = Item::<Config>::new("config");
         assert_eq!(cfg, reader.load(&store).unwrap());
 
-        let other_reader = Item::<Config>::new(b"config2");
+        let other_reader = Item::<Config>::new("config2");
         assert_eq!(other_reader.may_load(&store).unwrap(), None);
     }
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -19,9 +19,9 @@ pub struct Map<'a, K, T> {
 }
 
 impl<'a, K, T> Map<'a, K, T> {
-    pub const fn new(namespace: &'a [u8]) -> Self {
+    pub const fn new(namespace: &'a str) -> Self {
         Map {
-            namespace,
+            namespace: namespace.as_bytes(),
             data_type: PhantomData,
             key_type: PhantomData,
         }
@@ -114,9 +114,9 @@ mod test {
         pub age: i32,
     }
 
-    const PEOPLE: Map<&[u8], Data> = Map::new(b"people");
+    const PEOPLE: Map<&[u8], Data> = Map::new("people");
 
-    const ALLOWANCE: Map<(&[u8], &[u8]), u64> = Map::new(b"allow");
+    const ALLOWANCE: Map<(&[u8], &[u8]), u64> = Map::new("allow");
 
     #[test]
     fn create_path() {

--- a/packages/storage-plus/src/snapshot.rs
+++ b/packages/storage-plus/src/snapshot.rs
@@ -49,9 +49,9 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
         strategy: Strategy,
     ) -> Self {
         SnapshotMap {
-            primary: Map::new(pk.as_bytes()),
-            checkpoints: Map::new(checkpoints.as_bytes()),
-            changelog: Map::new(changelog.as_bytes()),
+            primary: Map::new(pk),
+            checkpoints: Map::new(checkpoints),
+            changelog: Map::new(changelog),
             strategy,
         }
     }


### PR DESCRIPTION
Closes #170.

I focused in names & ctors. Possibly other things can be changed as well, in other PR / PRs:

- key(), prefix()
- to_length_prefixed()
- nested_namespace_with_keys()
- load(), update(), save(), may_load(), ...
- Bound
- ...