### PR TITLE
Generalize UniqueIndex keys

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -484,23 +484,17 @@ mod test {
         let count = ages.len();
         assert_eq!(4, count);
 
-        // The (index) keys are the (unique, encoded) ages, in ascending order
-        assert_eq!(12u32.to_be_bytes(), ages[0].0.as_slice());
-        assert_eq!(13u32.to_be_bytes(), ages[1].0.as_slice());
-        assert_eq!(24u32.to_be_bytes(), ages[2].0.as_slice());
-        assert_eq!(42u32.to_be_bytes(), ages[3].0.as_slice());
+        // The pks
+        assert_eq!(b"5630".to_vec(), ages[0].0);
+        assert_eq!(b"5628".to_vec(), ages[1].0);
+        assert_eq!(b"5629".to_vec(), ages[2].0);
+        assert_eq!(b"5627".to_vec(), ages[3].0);
 
-        // The pks are in the (UniqueRef) values
-        assert_eq!(b"5630".to_vec(), ages[0].1.pk);
-        assert_eq!(b"5628".to_vec(), ages[1].1.pk);
-        assert_eq!(b"5629".to_vec(), ages[2].1.pk);
-        assert_eq!(b"5627".to_vec(), ages[3].1.pk);
-
-        // The associated data is in the (UniqueRef) values
-        assert_eq!(data4, ages[0].1.value);
-        assert_eq!(data2, ages[1].1.value);
-        assert_eq!(data3, ages[2].1.value);
-        assert_eq!(data1, ages[3].1.value);
+        // The associated data
+        assert_eq!(data4, ages[0].1);
+        assert_eq!(data2, ages[1].1);
+        assert_eq!(data3, ages[2].1);
+        assert_eq!(data1, ages[3].1);
     }
 
     #[test]
@@ -553,16 +547,12 @@ mod test {
         let count = marias.len();
         assert_eq!(2, count);
 
-        // The (index) keys are the (encoded) last names, in ascending order
-        assert_eq!(b"", marias[0].0.as_slice());
-        assert_eq!(b"Young", marias[1].0.as_slice());
+        // The pks
+        assert_eq!(b"5627".to_vec(), marias[0].0);
+        assert_eq!(b"5629".to_vec(), marias[1].0);
 
-        // The pks are in the (UniqueRef) values
-        assert_eq!(b"5627".to_vec(), marias[0].1.pk);
-        assert_eq!(b"5629".to_vec(), marias[1].1.pk);
-
-        // The associated data is in the (UniqueRef) values
-        assert_eq!(data1, marias[0].1.value);
-        assert_eq!(data3, marias[1].1.value);
+        // The associated data
+        assert_eq!(data1, marias[0].1);
+        assert_eq!(data3, marias[1].1);
     }
 }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -165,7 +165,7 @@ mod test {
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Data {
         pub name: String,
-        pub age: i32,
+        pub age: u32,
     }
 
     struct DataIndexes<'a> {
@@ -185,7 +185,7 @@ mod test {
     fn build_map<'a>() -> IndexedMap<'a, &'a [u8], Data, DataIndexes<'a>> {
         let indexes = DataIndexes {
             name: MultiIndex::new(|d| index_string(&d.name), "data", "data__name"),
-            age: UniqueIndex::new(|d| index_int(d.age as u32), "data__age"),
+            age: UniqueIndex::new(|d| index_int(d.age), "data__age"),
         };
         IndexedMap::new("data", indexes)
     }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -156,7 +156,7 @@ where
 mod test {
     use super::*;
 
-    use crate::indexes::{index_int, index_string, MultiIndex, UniqueIndex};
+    use crate::indexes::{index_string, MultiIndex, UniqueIndex};
     use crate::U32Key;
     use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::{MemoryStorage, Order};
@@ -185,7 +185,7 @@ mod test {
     fn build_map<'a>() -> IndexedMap<'a, &'a [u8], Data, DataIndexes<'a>> {
         let indexes = DataIndexes {
             name: MultiIndex::new(|d| index_string(&d.name), "data", "data__name"),
-            age: UniqueIndex::new(|d| index_int(d.age), "data__age"),
+            age: UniqueIndex::new(|d| U32Key::new(d.age), "data__age"),
         };
         IndexedMap::new("data", indexes)
     }
@@ -257,13 +257,13 @@ mod test {
         assert_eq!(0, count);
 
         // match on proper age
-        let proper = index_int(42);
+        let proper = U32Key::new(42);
         let aged = map.idx.age.item(&store, proper).unwrap().unwrap();
         assert_eq!(pk.to_vec(), aged.0);
         assert_eq!(data, aged.1);
 
         // no match on wrong age
-        let too_old = index_int(43);
+        let too_old = U32Key::new(43);
         let aged = map.idx.age.item(&store, too_old).unwrap();
         assert_eq!(None, aged);
     }
@@ -300,14 +300,14 @@ mod test {
 
         // query by unique key
         // match on proper age
-        let age42 = index_int(42);
+        let age42 = U32Key::new(42);
         let (k, v) = map.idx.age.item(&store, age42.clone()).unwrap().unwrap();
         assert_eq!(k.as_slice(), pk1);
         assert_eq!(&v.name, "Maria");
         assert_eq!(v.age, 42);
 
         // match on other age
-        let age23 = index_int(23);
+        let age23 = U32Key::new(23);
         let (k, v) = map.idx.age.item(&store, age23).unwrap().unwrap();
         assert_eq!(k.as_slice(), pk2);
         assert_eq!(&v.name, "Maria");

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -174,7 +174,7 @@ where
     }
 }
 
-pub(crate) fn deserialize_unique_kv<T: DeserializeOwned>(kv: KV) -> StdResult<KV<T>> {
+fn deserialize_unique_kv<T: DeserializeOwned>(kv: KV) -> StdResult<KV<T>> {
     let (_, v) = kv;
     let t = from_slice::<UniqueRef<T>>(&v)?;
     Ok((t.pk.into(), t.value))

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -8,13 +8,17 @@ use cosmwasm_std::{Binary, Order, StdError, StdResult, Storage, KV};
 
 use crate::map::Map;
 use crate::prefix::range_with_prefix;
-use crate::{Bound, PrimaryKey};
+use crate::{Bound, PkOwned, PrimaryKey};
 
 /// MARKER is stored in the multi-index as value, but we only look at the key (which is pk)
 const MARKER: u32 = 1;
 
 pub fn index_string(data: &str) -> Vec<u8> {
     data.as_bytes().to_vec()
+}
+
+pub fn index_string_tuple(data1: &str, data2: &str) -> (PkOwned, PkOwned) {
+    (PkOwned(index_string(data1)), PkOwned(index_string(data2)))
 }
 
 // 2 main variants:

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -6,22 +6,15 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Binary, Order, StdError, StdResult, Storage, KV};
 
-use crate::keys::IntKey;
 use crate::map::Map;
 use crate::prefix::range_with_prefix;
-use crate::{Bound, Endian, PrimaryKey};
+use crate::{Bound, PrimaryKey};
 
 /// MARKER is stored in the multi-index as value, but we only look at the key (which is pk)
 const MARKER: u32 = 1;
 
 pub fn index_string(data: &str) -> Vec<u8> {
     data.as_bytes().to_vec()
-}
-
-// Look at https://docs.rs/endiannezz/0.4.1/endiannezz/trait.Primitive.html
-// if you want to make this generic over all ints
-pub fn index_int<T: Endian>(data: T) -> IntKey<T> {
-    IntKey::<T>::new(data)
 }
 
 // 2 main variants:
@@ -43,7 +36,7 @@ where
 pub struct MultiIndex<'a, T> {
     index: fn(&T) -> Vec<u8>,
     idx_map: Map<'a, (&'a [u8], &'a [u8]), u32>,
-    // note, we collapse the pubkey - combining everything under the namespace - even if it is composite
+    // note, we collapse the pk - combining everything under the namespace - even if it is composite
     pk_map: Map<'a, &'a [u8], T>,
 }
 
@@ -126,15 +119,13 @@ where
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct UniqueRef<T> {
-    // note, we collapse the pubkey - combining everything under the namespace - even if it is composite
+    // note, we collapse the pk - combining everything under the namespace - even if it is composite
     pk: Binary,
     value: T,
 }
 
 pub struct UniqueIndex<'a, K, T> {
-    // index: fn(&T) -> Vec<u8>,
     index: fn(&T) -> K,
-    // idx_map: Map<'a, &'a [u8], UniqueRef<T>>,
     idx_map: Map<'a, K, UniqueRef<T>>,
 }
 

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -125,8 +125,8 @@ where
 #[derive(Deserialize, Serialize)]
 pub struct UniqueRef<T> {
     // note, we collapse the pk - combining everything under the namespace - even if it is composite
-    pk: Binary,
-    value: T,
+    pub pk: Binary,
+    pub value: T,
 }
 
 pub struct UniqueIndex<'a, K, T> {

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -162,6 +162,12 @@ pub type U32Key = IntKey<u32>;
 pub type U64Key = IntKey<u64>;
 pub type U128Key = IntKey<u128>;
 
+pub type I8Key = IntKey<i8>;
+pub type I16Key = IntKey<i16>;
+pub type I32Key = IntKey<i32>;
+pub type I64Key = IntKey<i64>;
+pub type I128Key = IntKey<i128>;
+
 /// It will cast one-particular int type into a Key via PkOwned, ensuring you don't mix up u32 and u64
 /// You can use new or the from/into pair to build a key from an int:
 ///

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -156,6 +156,7 @@ impl<'a, T: AsRef<PkOwned>> Prefixer<'a> for T {
     }
 }
 
+pub type U8Key = IntKey<u8>;
 pub type U16Key = IntKey<u16>;
 pub type U32Key = IntKey<u32>;
 pub type U64Key = IntKey<u64>;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -14,7 +14,7 @@ pub use endian::Endian;
 #[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};
 #[cfg(feature = "iterator")]
-pub use indexes::{index_int, index_string, Index, MultiIndex, UniqueIndex};
+pub use indexes::{index_string, Index, MultiIndex, UniqueIndex};
 pub use item::Item;
 pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
 pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -16,6 +16,7 @@ pub use indexed_map::{IndexList, IndexedMap};
 #[cfg(feature = "iterator")]
 pub use indexes::{index_int, index_string, Index, MultiIndex, UniqueIndex};
 pub use item::Item;
+pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
 pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
 pub use map::Map;
 pub use path::Path;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -16,7 +16,7 @@ pub use indexed_map::{IndexList, IndexedMap};
 #[cfg(feature = "iterator")]
 pub use indexes::{index_int, index_string, Index, MultiIndex, UniqueIndex};
 pub use item::Item;
-pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key};
+pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -14,7 +14,7 @@ pub use endian::Endian;
 #[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};
 #[cfg(feature = "iterator")]
-pub use indexes::{index_string, Index, MultiIndex, UniqueIndex};
+pub use indexes::{index_string, index_string_tuple, Index, MultiIndex, UniqueIndex};
 pub use item::Item;
 pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
 pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};


### PR DESCRIPTION
Closes #209.

Use generic index keys in `UniqueIndex`, so we can `prefix()` and `range()` over them.