### PR TITLE
Triple primary key 2

### DIFF
--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -370,6 +370,17 @@ mod test {
     }
 
     #[test]
+    fn parse_joined_keys_pk3_alt() {
+        type K<'a> = (&'a str, U64Key, &'a str);
+
+        let key: K = ("one", 222.into(), "three");
+        let joined = key.joined_key();
+        assert_eq!(3 + 8 + 5 + 2 * 2, joined.len());
+        let parsed = K::parse_key(&joined);
+        assert_eq!(key, parsed);
+    }
+
+    #[test]
     fn parse_joined_keys_int() {
         let key: U64Key = 12345678.into();
         let joined = key.joined_key();
@@ -380,11 +391,33 @@ mod test {
 
     #[test]
     fn parse_joined_keys_string_int() {
-        let key: (U32Key, &str) = (54321.into(), "random");
+        type K<'a> = (U32Key, &'a str);
+
+        let key: K = (54321.into(), "random");
         let joined = key.joined_key();
         assert_eq!(2 + 4 + 6, joined.len());
-        let parsed = <(U32Key, &str)>::parse_key(&joined);
+        let parsed = K::parse_key(&joined);
         assert_eq!(key, parsed);
         assert_eq!("random", parsed.1);
+    }
+
+    #[test]
+    fn proper_prefixes() {
+        let simple: &str = "hello";
+        assert_eq!(simple.prefix(), vec![b"hello"]);
+
+        let pair: (U32Key, &[u8]) = (12345.into(), b"random");
+        let one: Vec<u8> = vec![0, 0, 48, 57];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+
+        let triple: (&str, U32Key, &[u8]) = ("begin", 12345.into(), b"end");
+        let one: Vec<u8> = b"begin".to_vec();
+        let two: Vec<u8> = vec![0, 0, 48, 57];
+        let three: Vec<u8> = b"end".to_vec();
+        assert_eq!(
+            triple.prefix(),
+            vec![one.as_slice(), two.as_slice(), three.as_slice()]
+        );
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -79,7 +79,9 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for
 impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a> + Prefixer<'a>, V: PrimaryKey<'a>>
     PrimaryKey<'a> for (T, U, V)
 {
-    type Prefix = T;
+    // FIXME: Generalize
+    // type Prefix = (T, U);
+    type Prefix = Pk2<'a>;
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -22,16 +22,8 @@ pub trait PrimaryKey<'a>: Clone {
     fn parse_key(serialized: &'a [u8]) -> Self;
 }
 
-// optional type aliases to refer to them easier
-type Pk0 = ();
-type Pk1<'a> = &'a [u8];
-type Pk2<'a, T = &'a [u8], U = &'a [u8]> = (T, U);
-type Pk3<'a, T = &'a [u8], U = &'a [u8], V = &'a [u8]> = (T, U, V);
-
-type PkStr<'a> = &'a str;
-
-impl<'a> PrimaryKey<'a> for Pk1<'a> {
-    type Prefix = Pk0;
+impl<'a> PrimaryKey<'a> for &'a [u8] {
+    type Prefix = ();
 
     fn key<'b>(&'b self) -> Vec<&'b [u8]> {
         // this is simple, we don't add more prefixes
@@ -44,8 +36,8 @@ impl<'a> PrimaryKey<'a> for Pk1<'a> {
 }
 
 // Provide a string version of this to raw encode strings
-impl<'a> PrimaryKey<'a> for PkStr<'a> {
-    type Prefix = Pk0;
+impl<'a> PrimaryKey<'a> for &'a str {
+    type Prefix = ();
 
     fn key<'b>(&'b self) -> Vec<&'b [u8]> {
         // this is simple, we don't add more prefixes
@@ -79,9 +71,7 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for
 impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a> + Prefixer<'a>, V: PrimaryKey<'a>>
     PrimaryKey<'a> for (T, U, V)
 {
-    // FIXME: Generalize
-    // type Prefix = (T, U);
-    type Prefix = Pk2<'a>;
+    type Prefix = (T, U);
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();
@@ -110,32 +100,37 @@ pub trait Prefixer<'a> {
     fn prefix<'b>(&'b self) -> Vec<&'b [u8]>;
 }
 
-impl<'a> Prefixer<'a> for Pk0 {
+impl<'a> Prefixer<'a> for () {
     fn prefix<'b>(&'b self) -> Vec<&'b [u8]> {
         vec![]
     }
 }
 
-impl<'a> Prefixer<'a> for Pk1<'a> {
+impl<'a> Prefixer<'a> for &'a [u8] {
     fn prefix<'b>(&'b self) -> Vec<&'b [u8]> {
         vec![self]
     }
 }
 
-impl<'a> Prefixer<'a> for Pk2<'a> {
+impl<'a, T: Prefixer<'a>, U: Prefixer<'a>> Prefixer<'a> for (T, U) {
     fn prefix<'b>(&'b self) -> Vec<&'b [u8]> {
-        vec![self.0, self.1]
+        let mut res = self.0.prefix();
+        res.extend(self.1.prefix().into_iter());
+        res
     }
 }
 
-impl<'a> Prefixer<'a> for Pk3<'a> {
-    fn prefix(&self) -> Vec<&[u8]> {
-        vec![self.0, self.1, self.2]
+impl<'a, T: Prefixer<'a>, U: Prefixer<'a>, V: Prefixer<'a>> Prefixer<'a> for (T, U, V) {
+    fn prefix<'b>(&'b self) -> Vec<&'b [u8]> {
+        let mut res = self.0.prefix();
+        res.extend(self.1.prefix().into_iter());
+        res.extend(self.2.prefix().into_iter());
+        res
     }
 }
 
 // Provide a string version of this to raw encode strings
-impl<'a> Prefixer<'a> for PkStr<'a> {
+impl<'a> Prefixer<'a> for &'a str {
     fn prefix<'b>(&'b self) -> Vec<&'b [u8]> {
         vec![self.as_bytes()]
     }
@@ -281,19 +276,23 @@ mod test {
 
     #[test]
     fn str_key_works() {
-        let k: &str = "hello";
+        type K<'a> = &'a str;
+
+        let k: K = "hello";
         let path = k.key();
         assert_eq!(1, path.len());
         assert_eq!("hello".as_bytes(), path[0]);
 
         let joined = k.joined_key();
-        let parsed = PkStr::parse_key(&joined);
+        let parsed = K::parse_key(&joined);
         assert_eq!(parsed, "hello");
     }
 
     #[test]
     fn nested_str_key_works() {
-        let k: (&str, &[u8]) = ("hello", b"world");
+        type K<'a> = (&'a str, &'a [u8]);
+
+        let k: K = ("hello", b"world");
         let path = k.key();
         assert_eq!(2, path.len());
         assert_eq!("hello".as_bytes(), path[0]);
@@ -339,28 +338,34 @@ mod test {
 
     #[test]
     fn parse_joined_keys_pk1() {
-        let key: Pk1 = b"four";
+        type K<'a> = &'a [u8];
+
+        let key: K = b"four";
         let joined = key.joined_key();
         assert_eq!(key, joined.as_slice());
-        let parsed = Pk1::parse_key(&joined);
+        let parsed = K::parse_key(&joined);
         assert_eq!(key, parsed);
     }
 
     #[test]
     fn parse_joined_keys_pk2() {
-        let key: Pk2 = (b"four", b"square");
+        type K<'a> = (&'a [u8], &'a [u8]);
+
+        let key: K = (b"four", b"square");
         let joined = key.joined_key();
         assert_eq!(4 + 6 + 2, joined.len());
-        let parsed = Pk2::parse_key(&joined);
+        let parsed = K::parse_key(&joined);
         assert_eq!(key, parsed);
     }
 
     #[test]
     fn parse_joined_keys_pk3() {
-        let key: Pk3 = (b"four", b"square", b"cinco");
+        type K<'a> = (&'a str, U32Key, &'a [u8]);
+
+        let key: K = ("four", 15.into(), b"cinco");
         let joined = key.joined_key();
-        assert_eq!(4 + 6 + 5 + 2 * (3 - 1), joined.len());
-        let parsed = Pk3::parse_key(&joined);
+        assert_eq!(4 + 4 + 5 + 2 * 2, joined.len());
+        let parsed = K::parse_key(&joined);
         assert_eq!(key, parsed);
     }
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -132,7 +132,10 @@ mod test {
         let path = ALLOWANCE.key((b"john", b"maria"));
         let key = path.deref();
         // this should be prefixed(allow) || prefixed(john) || maria
-        assert_eq!("allow".len() + "john".len() + "maria".len() + 2 * 2, key.len());
+        assert_eq!(
+            "allow".len() + "john".len() + "maria".len() + 2 * 2,
+            key.len()
+        );
         assert_eq!(b"allow".to_vec().as_slice(), &key[2..7]);
         assert_eq!(b"john".to_vec().as_slice(), &key[9..13]);
         assert_eq!(b"maria".to_vec().as_slice(), &key[13..]);
@@ -205,11 +208,15 @@ mod test {
         assert_eq!(1234, triple.load(&store).unwrap());
 
         // not under other key
-        let different = TRIPLE.may_load(&store, (b"owners", b"spender", b"ecipient")).unwrap();
+        let different = TRIPLE
+            .may_load(&store, (b"owners", b"spender", b"ecipient"))
+            .unwrap();
         assert_eq!(None, different);
 
         // matches under a proper copy
-        let same = TRIPLE.load(&store, (b"owner", b"spender", b"recipient")).unwrap();
+        let same = TRIPLE
+            .load(&store, (b"owner", b"spender", b"recipient"))
+            .unwrap();
         assert_eq!(1234, same);
     }
 
@@ -295,7 +302,10 @@ mod test {
         assert_eq!(2, all.len());
         assert_eq!(
             all,
-            vec![(b"recipient".to_vec(), 1000), (b"recipient2".to_vec(), 3000)]
+            vec![
+                (b"recipient".to_vec(), 1000),
+                (b"recipient2".to_vec(), 3000)
+            ]
         );
     }
 


### PR DESCRIPTION
Follow-up of #210.

Fixes triple key `Prefix` type. Add `Map` triple keys tests.