### PR TITLE
Prefixer sub prefix

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -126,6 +126,11 @@ where
     pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
+
+    // use sub_prefix to scan -> range
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -189,6 +189,10 @@ where
         Prefix::new_de_fn(self.idx_namespace, &p.prefix(), deserialize_unique_kv)
     }
 
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+        Prefix::new_de_fn(self.idx_namespace, &p.prefix(), deserialize_unique_kv)
+    }
+
     /// returns all items that match this secondary index, always by pk Ascending
     pub fn item(&self, store: &dyn Storage, idx: K) -> StdResult<Option<KV<T>>> {
         let data = self

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -42,6 +42,11 @@ where
         Prefix::new(self.namespace, &p.prefix())
     }
 
+    #[cfg(feature = "iterator")]
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+        Prefix::new(self.namespace, &p.prefix())
+    }
+
     pub fn save(&self, store: &mut dyn Storage, k: K, data: &T) -> StdResult<()> {
         self.key(k).save(store, data)
     }
@@ -104,6 +109,8 @@ mod test {
     use serde::{Deserialize, Serialize};
     use std::ops::Deref;
 
+    #[cfg(feature = "iterator")]
+    use crate::iter_helpers::to_length_prefixed;
     use crate::U8Key;
     use cosmwasm_std::testing::MockStorage;
     #[cfg(feature = "iterator")]
@@ -291,6 +298,9 @@ mod test {
             .save(&mut store, (b"owner", 9u8.into(), "recipient2"), &3000)
             .unwrap();
         TRIPLE
+            .save(&mut store, (b"owner", 10u8.into(), "recipient3"), &3000)
+            .unwrap();
+        TRIPLE
             .save(&mut store, (b"owner2", 9u8.into(), "recipient"), &5000)
             .unwrap();
 
@@ -306,6 +316,32 @@ mod test {
             vec![
                 (b"recipient".to_vec(), 1000),
                 (b"recipient2".to_vec(), 3000)
+            ]
+        );
+
+        // let's iterate over a sub prefix
+        let all: StdResult<Vec<_>> = TRIPLE
+            .sub_prefix(b"owner")
+            .range(&store, None, None, Order::Ascending)
+            .collect();
+        let all = all.unwrap();
+        assert_eq!(3, all.len());
+        // FIXME: range() works, but remaining keys are still encoded
+        assert_eq!(
+            all,
+            vec![
+                (
+                    [to_length_prefixed(b"\x09"), b"recipient".to_vec()].concat(),
+                    1000
+                ),
+                (
+                    [to_length_prefixed(b"\x09"), b"recipient2".to_vec()].concat(),
+                    3000
+                ),
+                (
+                    [to_length_prefixed(b"\x0a"), b"recipient3".to_vec()].concat(),
+                    3000
+                )
             ]
         );
     }


### PR DESCRIPTION
Implemented first variant for #214.

**Update**: This turned out to be simpler, as the same `prefix()` method can be used for both, prefixes and sub-prefixes, after signalling which one through its related type alias / helper function.

Only missing piece is de-serialization of remaining keys, as they are being returned encoded. This can be tricky, as we don't have a regular format for keys, i. e. the first ones are length prefixed, but the last one isn't.
I think we can live with this: it's an issue only for `Map`, and probably `IndexedMap`. For `UniqueIndex`, and upcoming `MultiIndex` with sub-prefixes, this is already taken care of by the custom de-serialization function.