### PR TITLE
Upgrade to 0.14.0 alpha2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,7 +743,8 @@ jobs:
           command: cargo fmt -- --check
       - run:
           name: Clippy linting on workspace
-          command: cargo clippy -- -D warnings
+          # Silence false positive `field_reassing_with_default` (https://github.com/rust-lang/rust-clippy/issues/6545)
+          command: cargo clippy -- -D warnings -A clippy::field_reassign_with_default
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
 jobs:
   contract_cw1_subkeys:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw1-subkeys
     steps:
       - checkout:
@@ -49,7 +49,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw1-subkeys-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw1-subkeys-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -70,11 +70,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw1-subkeys-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw1-subkeys-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw1_whitelist:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw1-whitelist
     steps:
       - checkout:
@@ -84,7 +84,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw1-whitelist-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw1-whitelist-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -105,11 +105,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw1-whitelist-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw1-whitelist-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw20_atomic_swap:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw20-atomic-swap
     steps:
       - checkout:
@@ -119,7 +119,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw20-atomic-swap-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw20-atomic-swap-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -143,11 +143,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw20-atomic-swap-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw20-atomic-swap-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw3_fixed_multisig:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw3-fixed-multisig
     steps:
       - checkout:
@@ -157,7 +157,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw3-fixed-multisig-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw3-fixed-multisig-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -178,11 +178,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw3-fixed-multisig-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw3-fixed-multisig-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw3_flex_multisig:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw3-flex-multisig
     steps:
       - checkout:
@@ -192,7 +192,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw3-flex-multisig-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw3-flex-multisig-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -213,11 +213,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw3-flex-multisig-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw3-flex-multisig-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw4_group:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw4-group
     steps:
       - checkout:
@@ -227,7 +227,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw4-group-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw4-group-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -248,11 +248,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw4-group-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw4-group-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw4_stake:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw4-stake
     steps:
       - checkout:
@@ -262,7 +262,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw4-stake-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw4-stake-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -283,11 +283,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw4-stake-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw4-stake-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw20_base:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw20-base
     steps:
       - checkout:
@@ -297,7 +297,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw20-base-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw20-base-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -318,11 +318,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw20-base-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw20-base-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw20_bonding:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw20-bonding
     steps:
       - checkout:
@@ -332,7 +332,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw20-bonding-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw20-bonding-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -353,11 +353,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw20-bonding-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw20-bonding-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw20_escrow:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw20-escrow
     steps:
       - checkout:
@@ -367,7 +367,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw20-escrow-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw20-escrow-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -388,11 +388,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw20-escrow-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw20-escrow-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw20_staking:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw20-staking
     steps:
       - checkout:
@@ -402,7 +402,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw20-staking-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw20-staking-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -423,11 +423,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw20-staking-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw20-staking-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw721_base:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/contracts/cw721-base
     steps:
       - checkout:
@@ -437,7 +437,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-base-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-base-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           env: RUST_BACKTRACE=1
@@ -458,11 +458,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-base-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-base-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_controllers:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/controllers
     steps:
       - checkout:
@@ -472,7 +472,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-controllers:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-controllers:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -483,11 +483,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-controllers:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-controllers:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw0:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/cw0
     steps:
       - checkout:
@@ -497,7 +497,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw0:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw0:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -508,11 +508,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw0:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw0:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw1:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/cw1
     steps:
       - checkout:
@@ -522,7 +522,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw1:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw1:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -545,11 +545,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw1:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw1:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw2:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/cw2
     steps:
       - checkout:
@@ -559,7 +559,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw2:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw2:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -571,11 +571,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw2:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw2:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw3:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/cw3
     steps:
       - checkout:
@@ -585,7 +585,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw3:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw3:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -608,11 +608,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw3:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw3:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw4:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/cw4
     steps:
       - checkout:
@@ -622,7 +622,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw4:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw4:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -645,11 +645,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw4:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw4:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw20:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/cw20
     steps:
       - checkout:
@@ -659,7 +659,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw20:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw20:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -682,11 +682,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw20:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw20:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw721:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/cw721
     steps:
       - checkout:
@@ -696,7 +696,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw721:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw721:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -719,11 +719,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw721:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw721:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     steps:
       - checkout
       - run:
@@ -731,7 +731,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.50.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -750,14 +750,14 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.50.0-{{ checksum "Cargo.lock" }}
 
   # this runs one time on the top level to ensure all contracts compile properly into wasm
   # we don't run the wasm build and the reuse a lot of the same dependencies, so this should speed up CI time
   # for all the other tests
   wasm-build:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     steps:
       - checkout:
           path: ~/project
@@ -766,7 +766,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -777,11 +777,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_multi_test:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/multi-test
     steps:
       - checkout:
@@ -791,7 +791,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-multi-test:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -805,11 +805,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-multi-test:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_storage_plus:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.50.0
     working_directory: ~/project/packages/storage-plus
     steps:
       - checkout:
@@ -819,7 +819,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-storage-plus:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-storage-plus:1.50.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -836,7 +836,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-storage-plus:1.47.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-storage-plus:1.50.0-{{ checksum "~/project/Cargo.lock" }}
 
   # This job roughly follows the instructions from https://circleci.com/blog/publishing-to-github-releases-via-circleci/
   build_and_upload_contracts:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bitvec"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
+dependencies = [
+ "funty",
+ "radium",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,7 +32,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -46,19 +66,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
-name = "cosmwasm-derive"
-version = "0.13.2"
+name = "cfg-if"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de70197a0fe4e402aa260da00ec62d9bf091afe87866e9f3347691d591b60f89"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "const-oid"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "0.14.0-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0970930cd8ef7c43d22765cb69cd83bb5884b5eed71d01d135f436d7a5061caf"
+dependencies = [
+ "digest 0.9.0",
+ "ed25519-zebra",
+ "k256",
+ "rand_core",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-derive"
+version = "0.14.0-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7667ac05c9e67371d83595e0cc3706e1811b89ac42570f1864232d7de9ef7f38"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.13.2"
+version = "0.14.0-alpha2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98b56c1c839e5cfda1be0e0f152728b34bdcd5a2e921905947f6d088bab2c68"
+checksum = "fbbb3fce42afb4020a7356957e8573105d1957cc2d11632f6dc8e2f2ecaca449"
 dependencies = [
  "schemars",
  "serde_json",
@@ -66,11 +111,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.13.2"
+version = "0.14.0-alpha2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02173c4eb78ef76863f5190f60a45278d11e7c8b142327c149e18128b2b97f85"
+checksum = "1e4dc9edce6e2d7758547413c46fd701f7853b950b57700cb8f3ebfa40ae2c73"
 dependencies = [
  "base64",
+ "cosmwasm-crypto",
  "cosmwasm-derive",
  "schemars",
  "serde",
@@ -80,12 +126,41 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.13.2"
+version = "0.14.0-alpha2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cdb5f6c3181c921c02b0018af66178e60bc7be088f81ec730b22ff51240404"
+checksum = "1f41a29ea7e55465ce7a1d691ffa976d78925b3a6609139f8f2a85c191cfea56"
 dependencies = [
  "cosmwasm-std",
  "serde",
+]
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -201,10 +276,10 @@ dependencies = [
  "cw0",
  "cw2",
  "cw20",
- "hex",
+ "hex 0.3.2",
  "schemars",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "thiserror",
 ]
 
@@ -391,12 +466,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+dependencies = [
+ "elliptic-curve",
+ "hmac",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
+dependencies = [
+ "curve25519-dalek",
+ "hex 0.4.3",
+ "rand_core",
+ "serde",
+ "sha2 0.9.3",
+ "thiserror",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+dependencies = [
+ "bitvec",
+ "digest 0.9.0",
+ "ff",
+ "funty",
+ "generic-array 0.14.4",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -404,6 +540,23 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "ff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -415,16 +568,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
+name = "k256"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "num-integer"
@@ -452,6 +670,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "pkcs8"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+dependencies = [
+ "der",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +700,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -519,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294d94d390f1d2334697c065ea591d7074c676e2d20aa6f1df752fced29823f"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]
@@ -565,11 +813,40 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
+
+[[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+dependencies = [
+ "digest 0.9.0",
+ "rand_core",
+]
+
+[[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
@@ -613,3 +890,27 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -22,11 +22,11 @@ cw0 = { path = "../../packages/cw0", version = "0.5.0" }
 cw1 = { path = "../../packages/cw1", version = "0.5.0" }
 cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw1-whitelist = { path = "../cw1-whitelist", version = "0.5.0", features = ["library"] }
-cosmwasm-std = { version = "0.13.2", features = ["iterator", "staking"] }
-cosmwasm-storage = { version = "0.13.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["iterator", "staking"] }
+cosmwasm-storage = { version = "0.14.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw1-subkeys/schema/handle_msg.json
+++ b/contracts/cw1-subkeys/schema/handle_msg.json
@@ -154,8 +154,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -165,7 +167,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -174,9 +175,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -330,8 +328,10 @@
       }
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -355,6 +355,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -378,6 +379,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -408,6 +410,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -440,9 +443,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -460,7 +464,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -478,7 +482,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -488,6 +492,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -498,11 +503,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -517,6 +519,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/contracts/cw1-subkeys/schema/query_msg.json
+++ b/contracts/cw1-subkeys/schema/query_msg.json
@@ -145,8 +145,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -156,7 +158,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -165,9 +166,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -253,8 +251,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -278,6 +278,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -301,6 +302,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -331,6 +333,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -363,9 +366,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -383,7 +387,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -401,7 +405,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -411,6 +415,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -421,11 +426,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -440,6 +442,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -86,7 +86,7 @@ where
                 CosmosMsg::Staking(staking_msg) => {
                     let permissions = permissions(deps.storage);
                     let perm = permissions.may_load(owner_raw.as_slice())?;
-                    let perm = perm.ok_or_else(|| ContractError::NotAllowed {})?;
+                    let perm = perm.ok_or(ContractError::NotAllowed {})?;
 
                     check_staking_permissions(staking_msg, perm)?;
                 }
@@ -96,7 +96,7 @@ where
                 }) => {
                     let mut allowances = allowances(deps.storage);
                     let allow = allowances.may_load(owner_raw.as_slice())?;
-                    let mut allowance = allow.ok_or_else(|| ContractError::NoAllowance {})?;
+                    let mut allowance = allow.ok_or(ContractError::NoAllowance {})?;
                     // Decrease allowance
                     allowance.balance = allowance.balance.sub(amount.clone())?;
                     allowances.save(owner_raw.as_slice(), &allowance)?;
@@ -220,7 +220,7 @@ where
     let allowance =
         allowances(deps.storage).update::<_, ContractError>(spender_raw.as_slice(), |allow| {
             // Fail fast
-            let mut allowance = allow.ok_or_else(|| ContractError::NoAllowance {})?;
+            let mut allowance = allow.ok_or(ContractError::NoAllowance {})?;
             if let Some(exp) = expires {
                 allowance.expires = exp;
             }

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -21,11 +21,11 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
 cw1 = { path = "../../packages/cw1", version = "0.5.0" }
 cw2 = { path = "../../packages/cw2", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2", features = ["iterator"] }
-cosmwasm-storage = { version = "0.13.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["iterator"] }
+cosmwasm-storage = { version = "0.14.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw1-whitelist/schema/handle_msg.json
+++ b/contracts/cw1-whitelist/schema/handle_msg.json
@@ -63,8 +63,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -74,7 +76,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -83,9 +84,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -171,8 +169,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -196,6 +196,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -219,6 +220,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -249,6 +251,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -281,9 +284,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -301,7 +305,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -319,7 +323,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -329,6 +333,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -339,11 +344,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -358,6 +360,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/contracts/cw1-whitelist/schema/query_msg.json
+++ b/contracts/cw1-whitelist/schema/query_msg.json
@@ -41,8 +41,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -52,7 +54,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -61,9 +62,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -149,8 +147,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -174,6 +174,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -197,6 +198,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -227,6 +229,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -259,9 +262,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -279,7 +283,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -297,7 +301,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -307,6 +311,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -317,11 +322,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -336,6 +338,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/contracts/cw20-atomic-swap/Cargo.toml
+++ b/contracts/cw20-atomic-swap/Cargo.toml
@@ -18,8 +18,8 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
 cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw20 = { path = "../../packages/cw20", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2", features = ["iterator"] }
-cosmwasm-storage = { version = "0.13.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["iterator"] }
+cosmwasm-storage = { version = "0.14.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
@@ -27,4 +27,4 @@ hex = "0.3.1"
 sha2 = "0.8.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw20-atomic-swap/src/state.rs
+++ b/contracts/cw20-atomic-swap/src/state.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{Binary, BlockInfo, CanonicalAddr, Order, StdError, StdResult,
 use cosmwasm_storage::{bucket, bucket_read, prefixed_read, Bucket, ReadonlyBucket};
 use cw20::{Balance, Expiration};
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct AtomicSwap {
     /// This is the sha-256 hash of the preimage
     pub hash: Binary,
@@ -66,8 +66,9 @@ mod tests {
         AtomicSwap {
             recipient: CanonicalAddr(Binary(b"recip".to_vec())),
             source: CanonicalAddr(Binary(b"source".to_vec())),
+            expires: Default::default(),
             hash: Binary("hash".into()),
-            ..AtomicSwap::default()
+            balance: Default::default(),
         }
     }
 

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -21,11 +21,11 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
 cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw20 = { path = "../../packages/cw20", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2", features = ["iterator"] }
-cosmwasm-storage = { version = "0.13.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["iterator"] }
+cosmwasm-storage = { version = "0.14.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    attr, Binary, BlockInfo, CanonicalAddr, Deps, DepsMut, Env, HandleResponse, HumanAddr,
-    MessageInfo, StdResult, Storage, Uint128,
+    attr, Binary, BlockInfo, CanonicalAddr, Deps, DepsMut, Env, HumanAddr, MessageInfo, Response,
+    StdResult, Storage, Uint128,
 };
 use cw20::{AllowanceResponse, Cw20ReceiveMsg, Expiration};
 
@@ -14,7 +14,7 @@ pub fn handle_increase_allowance(
     spender: HumanAddr,
     amount: Uint128,
     expires: Option<Expiration>,
-) -> Result<HandleResponse, ContractError> {
+) -> Result<Response, ContractError> {
     let spender_raw = &deps.api.canonical_address(&spender)?;
     let owner_raw = &deps.api.canonical_address(&info.sender)?;
 
@@ -34,7 +34,8 @@ pub fn handle_increase_allowance(
         },
     )?;
 
-    let res = HandleResponse {
+    let res = Response {
+        submessages: vec![],
         messages: vec![],
         attributes: vec![
             attr("action", "increase_allowance"),
@@ -54,7 +55,7 @@ pub fn handle_decrease_allowance(
     spender: HumanAddr,
     amount: Uint128,
     expires: Option<Expiration>,
-) -> Result<HandleResponse, ContractError> {
+) -> Result<Response, ContractError> {
     let spender_raw = &deps.api.canonical_address(&spender)?;
     let owner_raw = &deps.api.canonical_address(&info.sender)?;
 
@@ -76,7 +77,8 @@ pub fn handle_decrease_allowance(
         allowances(deps.storage, owner_raw).remove(spender_raw.as_slice());
     }
 
-    let res = HandleResponse {
+    let res = Response {
+        submessages: vec![],
         messages: vec![],
         attributes: vec![
             attr("action", "decrease_allowance"),
@@ -120,7 +122,7 @@ pub fn handle_transfer_from(
     owner: HumanAddr,
     recipient: HumanAddr,
     amount: Uint128,
-) -> Result<HandleResponse, ContractError> {
+) -> Result<Response, ContractError> {
     let rcpt_raw = deps.api.canonical_address(&recipient)?;
     let owner_raw = deps.api.canonical_address(&owner)?;
     let spender_raw = deps.api.canonical_address(&info.sender)?;
@@ -137,7 +139,8 @@ pub fn handle_transfer_from(
         |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
     )?;
 
-    let res = HandleResponse {
+    let res = Response {
+        submessages: vec![],
         messages: vec![],
         attributes: vec![
             attr("action", "transfer_from"),
@@ -158,7 +161,7 @@ pub fn handle_burn_from(
     info: MessageInfo,
     owner: HumanAddr,
     amount: Uint128,
-) -> Result<HandleResponse, ContractError> {
+) -> Result<Response, ContractError> {
     let owner_raw = deps.api.canonical_address(&owner)?;
     let spender_raw = deps.api.canonical_address(&info.sender)?;
 
@@ -176,7 +179,8 @@ pub fn handle_burn_from(
         Ok(meta)
     })?;
 
-    let res = HandleResponse {
+    let res = Response {
+        submessages: vec![],
         messages: vec![],
         attributes: vec![
             attr("action", "burn_from"),
@@ -197,7 +201,7 @@ pub fn handle_send_from(
     contract: HumanAddr,
     amount: Uint128,
     msg: Option<Binary>,
-) -> Result<HandleResponse, ContractError> {
+) -> Result<Response, ContractError> {
     let rcpt_raw = deps.api.canonical_address(&contract)?;
     let owner_raw = deps.api.canonical_address(&owner)?;
     let spender_raw = deps.api.canonical_address(&info.sender)?;
@@ -232,7 +236,8 @@ pub fn handle_send_from(
     }
     .into_cosmos_msg(contract)?;
 
-    let res = HandleResponse {
+    let res = Response {
+        submessages: vec![],
         messages: vec![msg],
         attributes: attrs,
         data: None,

--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -7,7 +7,7 @@ use cw20::{AllowanceResponse, Cw20ReceiveMsg, Expiration};
 use crate::error::ContractError;
 use crate::state::{allowances, allowances_read, balances, token_info};
 
-pub fn handle_increase_allowance(
+pub fn execute_increase_allowance(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
@@ -48,7 +48,7 @@ pub fn handle_increase_allowance(
     Ok(res)
 }
 
-pub fn handle_decrease_allowance(
+pub fn execute_decrease_allowance(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
@@ -115,7 +115,7 @@ pub fn deduct_allowance(
     })
 }
 
-pub fn handle_transfer_from(
+pub fn execute_transfer_from(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -154,7 +154,7 @@ pub fn handle_transfer_from(
     Ok(res)
 }
 
-pub fn handle_burn_from(
+pub fn execute_burn_from(
     deps: DepsMut,
 
     env: Env,
@@ -193,7 +193,7 @@ pub fn handle_burn_from(
     Ok(res)
 }
 
-pub fn handle_send_from(
+pub fn execute_send_from(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -266,7 +266,7 @@ mod tests {
     use cosmwasm_std::{coins, CosmosMsg, StdError, WasmMsg};
     use cw20::{Cw20CoinHuman, TokenInfoResponse};
 
-    use crate::contract::{handle, init, query_balance, query_token_info};
+    use crate::contract::{execute, init, query_balance, query_token_info};
     use crate::msg::{HandleMsg, InitMsg};
 
     fn get_balance<T: Into<HumanAddr>>(deps: Deps, address: T) -> Uint128 {
@@ -313,7 +313,7 @@ mod tests {
             amount: allow1,
             expires: Some(expires.clone()),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // ensure it looks good
         let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
@@ -333,7 +333,7 @@ mod tests {
             amount: lower,
             expires: None,
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
         let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
         assert_eq!(
             allowance,
@@ -352,7 +352,7 @@ mod tests {
             amount: raise,
             expires: Some(new_expire.clone()),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
         let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
         assert_eq!(
             allowance,
@@ -368,7 +368,7 @@ mod tests {
             amount: Uint128(99988647623876347),
             expires: None,
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
         let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
         assert_eq!(allowance, AllowanceResponse::default());
     }
@@ -406,7 +406,7 @@ mod tests {
             amount: allow1,
             expires: Some(expires.clone()),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // set other allowance with no expiration
         let allow2 = Uint128(87654);
@@ -415,7 +415,7 @@ mod tests {
             amount: allow2,
             expires: None,
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // check they are proper
         let expect_one = AllowanceResponse {
@@ -449,7 +449,7 @@ mod tests {
             amount: allow3,
             expires: Some(expires3.clone()),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
         let expect_three = AllowanceResponse {
             allowance: allow3,
             expires: expires3,
@@ -483,7 +483,7 @@ mod tests {
             amount: Uint128(7777),
             expires: None,
         };
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::CannotSetOwnAccount {} => {}
             e => panic!("Unexpected error: {}", e),
@@ -495,7 +495,7 @@ mod tests {
             amount: Uint128(7777),
             expires: None,
         };
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::CannotSetOwnAccount {} => {}
             e => panic!("Unexpected error: {}", e),
@@ -521,7 +521,7 @@ mod tests {
         };
         let info = mock_info(owner.clone(), &[]);
         let env = mock_env();
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // valid transfer of part of the allowance
         let transfer = Uint128(44444);
@@ -532,7 +532,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
         assert_eq!(res.attributes[0], attr("action", "transfer_from"));
 
         // make sure money arrived
@@ -558,7 +558,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::Std(StdError::Underflow { .. }) => {}
             e => panic!("Unexpected error: {}", e),
@@ -572,7 +572,7 @@ mod tests {
             amount: Uint128(1000),
             expires: Some(Expiration::AtHeight(env.block.height)),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // we should now get the expiration error
         let msg = HandleMsg::TransferFrom {
@@ -582,7 +582,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::Expired {} => {}
             e => panic!("Unexpected error: {}", e),
@@ -607,7 +607,7 @@ mod tests {
         };
         let info = mock_info(owner.clone(), &[]);
         let env = mock_env();
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // valid burn of part of the allowance
         let transfer = Uint128(44444);
@@ -617,7 +617,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
         assert_eq!(res.attributes[0], attr("action", "burn_from"));
 
         // make sure money burnt
@@ -641,7 +641,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::Std(StdError::Underflow { .. }) => {}
             e => panic!("Unexpected error: {}", e),
@@ -655,7 +655,7 @@ mod tests {
             amount: Uint128(1000),
             expires: Some(Expiration::AtHeight(env.block.height)),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // we should now get the expiration error
         let msg = HandleMsg::BurnFrom {
@@ -664,7 +664,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::Expired {} => {}
             e => panic!("Unexpected error: {}", e),
@@ -691,7 +691,7 @@ mod tests {
         };
         let info = mock_info(owner.clone(), &[]);
         let env = mock_env();
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // valid send of part of the allowance
         let transfer = Uint128(44444);
@@ -703,7 +703,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
         assert_eq!(res.attributes[0], attr("action", "send_from"));
         assert_eq!(1, res.messages.len());
 
@@ -748,7 +748,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::Std(StdError::Underflow { .. }) => {}
             e => panic!("Unexpected error: {}", e),
@@ -762,7 +762,7 @@ mod tests {
             amount: Uint128(1000),
             expires: Some(Expiration::AtHeight(env.block.height)),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // we should now get the expiration error
         let msg = HandleMsg::SendFrom {
@@ -773,7 +773,7 @@ mod tests {
         };
         let info = mock_info(spender.clone(), &[]);
         let env = mock_env();
-        let res = handle(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         match res.unwrap_err() {
             ContractError::Expired {} => {}
             e => panic!("Unexpected error: {}", e),

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -64,7 +64,7 @@ mod tests {
     use cosmwasm_std::{coins, DepsMut, Uint128};
     use cw20::{Cw20CoinHuman, Expiration, TokenInfoResponse};
 
-    use crate::contract::{handle, init, query_token_info};
+    use crate::contract::{execute, init, query_token_info};
     use crate::msg::{HandleMsg, InitMsg};
 
     // this will set up the init for other tests
@@ -110,7 +110,7 @@ mod tests {
             amount: allow1,
             expires: Some(expires.clone()),
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // set allowance with no expiration
         let allow2 = Uint128(54321);
@@ -119,7 +119,7 @@ mod tests {
             amount: allow2,
             expires: None,
         };
-        handle(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         // query list gets 2
         let allowances = query_all_allowances(deps.as_ref(), owner.clone(), None, None).unwrap();
@@ -164,7 +164,7 @@ mod tests {
         // put money everywhere (to create balanaces)
         let info = mock_info(acct1.clone(), &[]);
         let env = mock_env();
-        handle(
+        execute(
             deps.as_mut(),
             env.clone(),
             info.clone(),
@@ -174,7 +174,7 @@ mod tests {
             },
         )
         .unwrap();
-        handle(
+        execute(
             deps.as_mut(),
             env.clone(),
             info.clone(),
@@ -184,7 +184,7 @@ mod tests {
             },
         )
         .unwrap();
-        handle(
+        execute(
             deps.as_mut(),
             env.clone(),
             info.clone(),

--- a/contracts/cw20-bonding/Cargo.toml
+++ b/contracts/cw20-bonding/Cargo.toml
@@ -25,7 +25,7 @@ cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw20 = { path = "../../packages/cw20", version = "0.5.0" }
 cw20-base = { path = "../../contracts/cw20-base", version = "0.5.0", features = ["library"] }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2", features = ["staking"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["staking"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
@@ -33,4 +33,4 @@ rust_decimal = { version = "1.8.1" }
 num-integer = { version = "0.1.44" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw20-bonding/schema/init_msg.json
+++ b/contracts/cw20-bonding/schema/init_msg.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "curve_type": {
-      "description": "enum to store the curve parameters used for this contract if you want to add a custom Curve, you should make a new contract that imports this one. write a custom `init`, and then dispatch `your::handle` -> `cw20_bonding::do_handle` with your custom curve as a parameter (and same with `query` -> `do_query`)",
+      "description": "enum to store the curve parameters used for this contract if you want to add a custom Curve, you should make a new contract that imports this one. write a custom `init`, and then dispatch `your::execute` -> `cw20_bonding::do_execute` with your custom curve as a parameter (and same with `query` -> `do_query`)",
       "allOf": [
         {
           "$ref": "#/definitions/CurveType"

--- a/contracts/cw20-bonding/src/contract.rs
+++ b/contracts/cw20-bonding/src/contract.rs
@@ -5,11 +5,11 @@ use cosmwasm_std::{
 
 use cw2::set_contract_version;
 use cw20_base::allowances::{
-    deduct_allowance, handle_decrease_allowance, handle_increase_allowance, handle_send_from,
-    handle_transfer_from, query_allowance,
+    deduct_allowance, execute_decrease_allowance, execute_increase_allowance, execute_send_from,
+    execute_transfer_from, query_allowance,
 };
 use cw20_base::contract::{
-    handle_burn, handle_mint, handle_send, handle_transfer, query_balance, query_token_info,
+    execute_burn, execute_mint, execute_send, execute_transfer, query_balance, query_token_info,
 };
 use cw20_base::state::{token_info, MinterData, TokenInfo};
 
@@ -38,7 +38,7 @@ pub fn init(
         symbol: msg.symbol,
         decimals: msg.decimals,
         total_supply: Uint128(0),
-        // set self as minter, so we can properly handle mint and burn
+        // set self as minter, so we can properly execute mint and burn
         mint: Some(MinterData {
             minter: deps.api.canonical_address(&env.contract.address)?,
             cap: None,
@@ -55,23 +55,23 @@ pub fn init(
     Ok(Response::default())
 }
 
-pub fn handle(
+pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
 ) -> Result<Response, ContractError> {
     // default implementation stores curve info as enum, you can do something else in a derived
-    // contract and just pass in your custom curve to do_handle
+    // contract and just pass in your custom curve to do_execute
     let curve_type = CURVE_TYPE.load(deps.storage)?;
     let curve_fn = curve_type.to_curve_fn();
-    do_handle(deps, env, info, msg, curve_fn)
+    do_execute(deps, env, info, msg, curve_fn)
 }
 
 /// We pull out logic here, so we can import this from another contract and set a different Curve.
 /// This contacts sets a curve with an enum in InitMsg and stored in state, but you may want to
 /// use custom math not included - make this easily reusable
-pub fn do_handle(
+pub fn do_execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -79,42 +79,42 @@ pub fn do_handle(
     curve_fn: CurveFn,
 ) -> Result<Response, ContractError> {
     match msg {
-        HandleMsg::Buy {} => handle_buy(deps, env, info, curve_fn),
+        HandleMsg::Buy {} => execute_buy(deps, env, info, curve_fn),
 
         // we override these from cw20
-        HandleMsg::Burn { amount } => Ok(handle_sell(deps, env, info, curve_fn, amount)?),
+        HandleMsg::Burn { amount } => Ok(execute_sell(deps, env, info, curve_fn, amount)?),
         HandleMsg::BurnFrom { owner, amount } => {
-            Ok(handle_sell_from(deps, env, info, curve_fn, owner, amount)?)
+            Ok(execute_sell_from(deps, env, info, curve_fn, owner, amount)?)
         }
 
         // these all come from cw20-base to implement the cw20 standard
         HandleMsg::Transfer { recipient, amount } => {
-            Ok(handle_transfer(deps, env, info, recipient, amount)?)
+            Ok(execute_transfer(deps, env, info, recipient, amount)?)
         }
         HandleMsg::Send {
             contract,
             amount,
             msg,
-        } => Ok(handle_send(deps, env, info, contract, amount, msg)?),
+        } => Ok(execute_send(deps, env, info, contract, amount, msg)?),
         HandleMsg::IncreaseAllowance {
             spender,
             amount,
             expires,
-        } => Ok(handle_increase_allowance(
+        } => Ok(execute_increase_allowance(
             deps, env, info, spender, amount, expires,
         )?),
         HandleMsg::DecreaseAllowance {
             spender,
             amount,
             expires,
-        } => Ok(handle_decrease_allowance(
+        } => Ok(execute_decrease_allowance(
             deps, env, info, spender, amount, expires,
         )?),
         HandleMsg::TransferFrom {
             owner,
             recipient,
             amount,
-        } => Ok(handle_transfer_from(
+        } => Ok(execute_transfer_from(
             deps, env, info, owner, recipient, amount,
         )?),
         HandleMsg::SendFrom {
@@ -122,13 +122,13 @@ pub fn do_handle(
             contract,
             amount,
             msg,
-        } => Ok(handle_send_from(
+        } => Ok(execute_send_from(
             deps, env, info, owner, contract, amount, msg,
         )?),
     }
 }
 
-pub fn handle_buy(
+pub fn execute_buy(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -151,7 +151,7 @@ pub fn handle_buy(
         sender: env.contract.address.clone(),
         funds: vec![],
     };
-    handle_mint(deps, env, sub_info, info.sender.clone(), minted)?;
+    execute_mint(deps, env, sub_info, info.sender.clone(), minted)?;
 
     // bond them to the validator
     let res = Response {
@@ -168,7 +168,7 @@ pub fn handle_buy(
     Ok(res)
 }
 
-pub fn handle_sell(
+pub fn execute_sell(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -185,7 +185,7 @@ pub fn handle_sell(
     Ok(res)
 }
 
-pub fn handle_sell_from(
+pub fn execute_sell_from(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -220,12 +220,12 @@ fn do_sell(
     // info.sender is the one burning tokens
     info: MessageInfo,
     curve_fn: CurveFn,
-    // receiver is the one who gains (same for handle_sell, diff for handle_sell_from)
+    // receiver is the one who gains (same for execute_sell, diff for execute_sell_from)
     receiver: HumanAddr,
     amount: Uint128,
 ) -> Result<Response, ContractError> {
     // burn from the caller, this ensures there are tokens to cover this
-    handle_burn(deps.branch(), env, info.clone(), amount)?;
+    execute_burn(deps.branch(), env, info.clone(), amount)?;
 
     // calculate how many tokens can be purchased with this and mint them
     let mut state = CURVE_STATE.load(deps.storage)?;
@@ -256,7 +256,7 @@ fn do_sell(
 
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     // default implementation stores curve info as enum, you can do something else in a derived
-    // contract and just pass in your custom curve to do_handle
+    // contract and just pass in your custom curve to do_execute
     let curve_type = CURVE_TYPE.load(deps.storage)?;
     let curve_fn = curve_type.to_curve_fn();
     do_query(deps, env, msg, curve_fn)
@@ -390,7 +390,7 @@ mod tests {
         // succeeds with proper token (5 BTC = 5*10^8 satoshi)
         let info = mock_info(INVESTOR, &coins(500_000_000, DENOM));
         let buy = HandleMsg::Buy {};
-        handle(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
+        execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
 
         // bob got 1000 EPOXY (10.00)
         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128(1000));
@@ -402,7 +402,7 @@ mod tests {
             recipient: BUYER.into(),
             amount: Uint128(1000),
         };
-        handle(deps.as_mut(), mock_env(), info, send).unwrap();
+        execute(deps.as_mut(), mock_env(), info, send).unwrap();
 
         // ensure balances updated
         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128(0));
@@ -410,7 +410,7 @@ mod tests {
 
         // second stake needs more to get next 1000 EPOXY
         let info = mock_info(INVESTOR, &coins(1_500_000_000, DENOM));
-        handle(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
+        execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
 
         // ensure balances updated
         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128(1000));
@@ -440,17 +440,17 @@ mod tests {
         // fails when no tokens sent
         let info = mock_info(INVESTOR, &[]);
         let buy = HandleMsg::Buy {};
-        let err = handle(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
         assert_eq!(err, PaymentError::NoFunds {}.into());
 
         // fails when wrong tokens sent
         let info = mock_info(INVESTOR, &coins(1234567, "wei"));
-        let err = handle(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
         assert_eq!(err, PaymentError::MissingDenom(DENOM.into()).into());
 
         // fails when too many tokens sent
         let info = mock_info(INVESTOR, &[coin(3400022, DENOM), coin(1234567, "wei")]);
-        let err = handle(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
         assert_eq!(err, PaymentError::ExtraDenom("wei".to_string()).into());
     }
 
@@ -466,7 +466,7 @@ mod tests {
         // succeeds with proper token (20 BTC = 20*10^8 satoshi)
         let info = mock_info(INVESTOR, &coins(2_000_000_000, DENOM));
         let buy = HandleMsg::Buy {};
-        handle(deps.as_mut(), mock_env(), info, buy).unwrap();
+        execute(deps.as_mut(), mock_env(), info, buy).unwrap();
 
         // bob got 2000 EPOXY (20.00)
         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128(2000));
@@ -476,7 +476,7 @@ mod tests {
         let burn = HandleMsg::Burn {
             amount: Uint128(3000),
         };
-        let err = handle(deps.as_mut(), mock_env(), info, burn).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, burn).unwrap_err();
         assert_eq!("Cannot subtract 3000 from 2000", err.to_string().as_str());
 
         // burn 1000 EPOXY to get back 15BTC (*10^8)
@@ -484,7 +484,7 @@ mod tests {
         let burn = HandleMsg::Burn {
             amount: Uint128(1000),
         };
-        let res = handle(deps.as_mut(), mock_env(), info, burn).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, burn).unwrap();
 
         // balance is lower
         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128(1000));
@@ -528,7 +528,7 @@ mod tests {
         // spend 45_000 uatom for 30_000_000 EPOXY
         let info = mock_info(bob, &coins(45_000, DENOM));
         let buy = HandleMsg::Buy {};
-        handle(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
+        execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
 
         // check balances
         assert_eq!(get_balance(deps.as_ref(), bob), Uint128(30_000_000));
@@ -540,7 +540,7 @@ mod tests {
             recipient: carl.into(),
             amount: Uint128(2_000_000),
         };
-        handle(deps.as_mut(), mock_env(), bob_info.clone(), transfer).unwrap();
+        execute(deps.as_mut(), mock_env(), bob_info.clone(), transfer).unwrap();
         assert_eq!(get_balance(deps.as_ref(), bob), Uint128(28_000_000));
         assert_eq!(get_balance(deps.as_ref(), carl), Uint128(2_000_000));
 
@@ -550,7 +550,7 @@ mod tests {
             amount: Uint128(35_000_000),
             expires: None,
         };
-        handle(deps.as_mut(), mock_env(), bob_info.clone(), allow).unwrap();
+        execute(deps.as_mut(), mock_env(), bob_info.clone(), allow).unwrap();
         assert_eq!(get_balance(deps.as_ref(), bob), Uint128(28_000_000));
         assert_eq!(get_balance(deps.as_ref(), alice), Uint128(0));
         assert_eq!(
@@ -567,7 +567,7 @@ mod tests {
             amount: Uint128(25_000_000),
         };
         let alice_info = mock_info(alice, &[]);
-        handle(deps.as_mut(), mock_env(), alice_info.clone(), self_pay).unwrap();
+        execute(deps.as_mut(), mock_env(), alice_info.clone(), self_pay).unwrap();
         assert_eq!(get_balance(deps.as_ref(), bob), Uint128(3_000_000));
         assert_eq!(get_balance(deps.as_ref(), alice), Uint128(25_000_000));
         assert_eq!(get_balance(deps.as_ref(), carl), Uint128(2_000_000));
@@ -586,7 +586,7 @@ mod tests {
             owner: bob.into(),
             amount: Uint128(3_300_000),
         };
-        let err = handle(deps.as_mut(), mock_env(), info, burn_from).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, burn_from).unwrap_err();
         assert_eq!(
             "Cannot subtract 3300000 from 3000000",
             err.to_string().as_str()
@@ -598,7 +598,7 @@ mod tests {
             owner: bob.into(),
             amount: Uint128(1_000_000),
         };
-        let res = handle(deps.as_mut(), mock_env(), info, burn_from).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, burn_from).unwrap();
 
         // bob balance is lower, not alice
         assert_eq!(get_balance(deps.as_ref(), alice), Uint128(25_000_000));

--- a/contracts/cw20-bonding/src/contract.rs
+++ b/contracts/cw20-bonding/src/contract.rs
@@ -225,7 +225,7 @@ fn do_sell(
     amount: Uint128,
 ) -> Result<Response, ContractError> {
     // burn from the caller, this ensures there are tokens to cover this
-    handle_burn(deps.branch(), env.clone(), info.clone(), amount)?;
+    handle_burn(deps.branch(), env, info.clone(), amount)?;
 
     // calculate how many tokens can be purchased with this and mint them
     let mut state = CURVE_STATE.load(deps.storage)?;

--- a/contracts/cw20-bonding/src/curves.rs
+++ b/contracts/cw20-bonding/src/curves.rs
@@ -44,7 +44,7 @@ pub fn decimal<T: Into<u128>>(num: T, scale: u32) -> Decimal {
 /// StdDecimal stores as a u128 with 18 decimal points of precision
 fn decimal_to_std(x: Decimal) -> StdDecimal {
     // this seems straight-forward (if inefficient), converting via string representation
-    // TODO: handle errors better? Result?
+    // TODO: execute errors better? Result?
     StdDecimal::from_str(&x.to_string()).unwrap()
 
     // // maybe a better approach doing math, not sure about rounding
@@ -220,14 +220,14 @@ impl DecimalPlaces {
     pub fn to_reserve(&self, reserve: Decimal) -> Uint128 {
         let factor = decimal(10u128.pow(self.reserve), 0);
         let out = reserve * factor;
-        // TODO: handle overflow better? Result?
+        // TODO: execute overflow better? Result?
         out.floor().to_u128().unwrap().into()
     }
 
     pub fn to_supply(&self, supply: Decimal) -> Uint128 {
         let factor = decimal(10u128.pow(self.supply), 0);
         let out = supply * factor;
-        // TODO: handle overflow better? Result?
+        // TODO: execute overflow better? Result?
         out.floor().to_u128().unwrap().into()
     }
 

--- a/contracts/cw20-bonding/src/msg.rs
+++ b/contracts/cw20-bonding/src/msg.rs
@@ -23,7 +23,7 @@ pub struct InitMsg {
 
     /// enum to store the curve parameters used for this contract
     /// if you want to add a custom Curve, you should make a new contract that imports this one.
-    /// write a custom `init`, and then dispatch `your::handle` -> `cw20_bonding::do_handle` with
+    /// write a custom `init`, and then dispatch `your::execute` -> `cw20_bonding::do_execute` with
     /// your custom curve as a parameter (and same with `query` -> `do_query`)
     pub curve_type: CurveType,
 }

--- a/contracts/cw20-escrow/Cargo.toml
+++ b/contracts/cw20-escrow/Cargo.toml
@@ -21,13 +21,13 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
 cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw20 = { path = "../../packages/cw20", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2", features = ["iterator"] }
-cosmwasm-storage = { version = "0.13.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["iterator"] }
+cosmwasm-storage = { version = "0.14.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }
 cw-multi-test = { path = "../../packages/multi-test", version = "0.5.0" }
 cw20-base = { path = "../cw20-base", version = "0.5.0", features = ["library"] }

--- a/contracts/cw20-escrow/src/integration_test.rs
+++ b/contracts/cw20-escrow/src/integration_test.rs
@@ -17,7 +17,7 @@ fn mock_app() -> App {
 
 pub fn contract_escrow() -> Box<dyn Contract> {
     let contract = ContractWrapper::new(
-        crate::contract::handle,
+        crate::contract::execute,
         crate::contract::init,
         crate::contract::query,
     );
@@ -26,7 +26,7 @@ pub fn contract_escrow() -> Box<dyn Contract> {
 
 pub fn contract_cw20() -> Box<dyn Contract> {
     let contract = ContractWrapper::new(
-        cw20_base::contract::handle,
+        cw20_base::contract::execute,
         cw20_base::contract::init,
         cw20_base::contract::query,
     );

--- a/contracts/cw20-escrow/src/state.rs
+++ b/contracts/cw20-escrow/src/state.rs
@@ -47,7 +47,7 @@ impl GenericBalance {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Escrow {
     /// arbiter can decide to approve or refund the escrow
     pub arbiter: CanonicalAddr,
@@ -132,7 +132,10 @@ mod tests {
             arbiter: CanonicalAddr(Binary(b"arb".to_vec())),
             recipient: CanonicalAddr(Binary(b"recip".to_vec())),
             source: CanonicalAddr(Binary(b"source".to_vec())),
-            ..Escrow::default()
+            end_height: None,
+            end_time: None,
+            balance: Default::default(),
+            cw20_whitelist: vec![],
         }
     }
 

--- a/contracts/cw20-staking/Cargo.toml
+++ b/contracts/cw20-staking/Cargo.toml
@@ -25,11 +25,11 @@ cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw20 = { path = "../../packages/cw20", version = "0.5.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.5.0" }
 cw20-base = { path = "../../contracts/cw20-base", version = "0.5.0", features = ["library"] }
-cosmwasm-std = { version = "0.13.2", features = ["staking"] }
-cosmwasm-storage = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["staking"] }
+cosmwasm-storage = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw20-staking/src/contract.rs
+++ b/contracts/cw20-staking/src/contract.rs
@@ -5,11 +5,11 @@ use cosmwasm_std::{
 
 use cw2::set_contract_version;
 use cw20_base::allowances::{
-    handle_burn_from, handle_decrease_allowance, handle_increase_allowance, handle_send_from,
-    handle_transfer_from, query_allowance,
+    execute_burn_from, execute_decrease_allowance, execute_increase_allowance, execute_send_from,
+    execute_transfer_from, query_allowance,
 };
 use cw20_base::contract::{
-    handle_burn, handle_mint, handle_send, handle_transfer, query_balance, query_token_info,
+    execute_burn, execute_mint, execute_send, execute_transfer, query_balance, query_token_info,
 };
 use cw20_base::state::{token_info, MinterData, TokenInfo};
 
@@ -47,7 +47,7 @@ pub fn init(
         symbol: msg.symbol,
         decimals: msg.decimals,
         total_supply: Uint128(0),
-        // set self as minter, so we can properly handle mint and burn
+        // set self as minter, so we can properly execute mint and burn
         mint: Some(MinterData {
             minter: deps.api.canonical_address(&env.contract.address)?,
             cap: None,
@@ -73,7 +73,7 @@ pub fn init(
     Ok(Response::default())
 }
 
-pub fn handle(
+pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -88,44 +88,44 @@ pub fn handle(
 
         // these all come from cw20-base to implement the cw20 standard
         HandleMsg::Transfer { recipient, amount } => {
-            Ok(handle_transfer(deps, env, info, recipient, amount)?)
+            Ok(execute_transfer(deps, env, info, recipient, amount)?)
         }
-        HandleMsg::Burn { amount } => Ok(handle_burn(deps, env, info, amount)?),
+        HandleMsg::Burn { amount } => Ok(execute_burn(deps, env, info, amount)?),
         HandleMsg::Send {
             contract,
             amount,
             msg,
-        } => Ok(handle_send(deps, env, info, contract, amount, msg)?),
+        } => Ok(execute_send(deps, env, info, contract, amount, msg)?),
         HandleMsg::IncreaseAllowance {
             spender,
             amount,
             expires,
-        } => Ok(handle_increase_allowance(
+        } => Ok(execute_increase_allowance(
             deps, env, info, spender, amount, expires,
         )?),
         HandleMsg::DecreaseAllowance {
             spender,
             amount,
             expires,
-        } => Ok(handle_decrease_allowance(
+        } => Ok(execute_decrease_allowance(
             deps, env, info, spender, amount, expires,
         )?),
         HandleMsg::TransferFrom {
             owner,
             recipient,
             amount,
-        } => Ok(handle_transfer_from(
+        } => Ok(execute_transfer_from(
             deps, env, info, owner, recipient, amount,
         )?),
         HandleMsg::BurnFrom { owner, amount } => {
-            Ok(handle_burn_from(deps, env, info, owner, amount)?)
+            Ok(execute_burn_from(deps, env, info, owner, amount)?)
         }
         HandleMsg::SendFrom {
             owner,
             contract,
             amount,
             msg,
-        } => Ok(handle_send_from(
+        } => Ok(execute_send_from(
             deps, env, info, owner, contract, amount, msg,
         )?),
     }
@@ -199,7 +199,7 @@ pub fn bond(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Cont
         sender: env.contract.address.clone(),
         funds: vec![],
     };
-    handle_mint(deps, env, sub_info, info.sender.clone(), to_mint)?;
+    execute_mint(deps, env, sub_info, info.sender.clone(), to_mint)?;
 
     // bond them to the validator
     let res = Response {
@@ -240,7 +240,7 @@ pub fn unbond(
     let tax = amount * invest.exit_tax;
 
     // burn from the original caller
-    handle_burn(deps.branch(), env.clone(), info.clone(), amount)?;
+    execute_burn(deps.branch(), env.clone(), info.clone(), amount)?;
     if tax > Uint128(0) {
         let sub_info = MessageInfo {
             sender: env.contract.address.clone(),
@@ -248,7 +248,7 @@ pub fn unbond(
         };
         // call into cw20-base to mint tokens to owner, call as self as no one else is allowed
         let human_owner = deps.api.human_address(&invest.owner)?;
-        handle_mint(deps.branch(), env.clone(), sub_info, human_owner, tax)?;
+        execute_mint(deps.branch(), env.clone(), sub_info, human_owner, tax)?;
     }
 
     // re-calculate bonded to ensure we have real values
@@ -624,7 +624,7 @@ mod tests {
         let info = mock_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
 
         // try to bond and make sure we trigger delegation
-        let res = handle(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
         assert_eq!(1, res.messages.len());
         let delegate = &res.messages[0];
         match delegate {
@@ -666,7 +666,7 @@ mod tests {
         let bob = HumanAddr::from("bob");
         let bond_msg = HandleMsg::Bond {};
         let info = mock_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
-        let res = handle(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
         assert_eq!(1, res.messages.len());
 
         // update the querier with new bond
@@ -677,7 +677,7 @@ mod tests {
         let info = mock_info(MOCK_CONTRACT_ADDR, &[]);
         deps.querier
             .update_balance(MOCK_CONTRACT_ADDR, coins(500, "ustake"));
-        let _ = handle(deps.as_mut(), mock_env(), info, rebond_msg).unwrap();
+        let _ = execute(deps.as_mut(), mock_env(), info, rebond_msg).unwrap();
 
         // update the querier with new bond
         set_delegation(&mut deps.querier, 1500, "ustake");
@@ -693,7 +693,7 @@ mod tests {
         let alice = HumanAddr::from("alice");
         let bond_msg = HandleMsg::Bond {};
         let info = mock_info(&alice, &[coin(3000, "ustake")]);
-        let res = handle(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
         assert_eq!(1, res.messages.len());
 
         // update the querier with new bond
@@ -727,7 +727,7 @@ mod tests {
         let info = mock_info(&bob, &[coin(500, "photon")]);
 
         // try to bond and make sure we trigger delegation
-        let res = handle(deps.as_mut(), mock_env(), info, bond_msg);
+        let res = execute(deps.as_mut(), mock_env(), info, bond_msg);
         match res.unwrap_err() {
             ContractError::EmptyBalance { .. } => {}
             e => panic!("Expected wrong denom error, got: {:?}", e),
@@ -751,7 +751,7 @@ mod tests {
         let bob = HumanAddr::from("bob");
         let bond_msg = HandleMsg::Bond {};
         let info = mock_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
-        let res = handle(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
         assert_eq!(1, res.messages.len());
 
         // update the querier with new bond
@@ -763,7 +763,7 @@ mod tests {
         let info = mock_info(MOCK_CONTRACT_ADDR, &[]);
         deps.querier
             .update_balance(MOCK_CONTRACT_ADDR, coins(500, "ustake"));
-        let _ = handle(deps.as_mut(), mock_env(), info, rebond_msg).unwrap();
+        let _ = execute(deps.as_mut(), mock_env(), info, rebond_msg).unwrap();
 
         // update the querier with new bond, lower balance
         set_delegation(&mut deps.querier, 1500, "ustake");
@@ -774,7 +774,7 @@ mod tests {
             amount: Uint128(600),
         };
         let info = mock_info(&creator, &[]);
-        let res = handle(deps.as_mut(), mock_env(), info, unbond_msg);
+        let res = execute(deps.as_mut(), mock_env(), info, unbond_msg);
         match res.unwrap_err() {
             ContractError::Std(StdError::Underflow { .. }) => {}
             e => panic!("unexpected error: {}", e),
@@ -791,7 +791,7 @@ mod tests {
         let bobs_balance = Uint128(400);
         let env = mock_env();
         let info = mock_info(&bob, &[]);
-        let res = handle(deps.as_mut(), env.clone(), info, unbond_msg).unwrap();
+        let res = execute(deps.as_mut(), env.clone(), info, unbond_msg).unwrap();
         assert_eq!(1, res.messages.len());
         let delegate = &res.messages[0];
         match delegate {
@@ -838,7 +838,7 @@ mod tests {
         // bond some tokens
         let bob = HumanAddr::from("bob");
         let info = mock_info(&bob, &coins(1000, "ustake"));
-        handle(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
+        execute(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
         set_delegation(&mut deps.querier, 1000, "ustake");
 
         // unbond part of them
@@ -847,7 +847,7 @@ mod tests {
         };
         let env = mock_env();
         let info = mock_info(&bob, &[]);
-        handle(deps.as_mut(), env.clone(), info.clone(), unbond_msg).unwrap();
+        execute(deps.as_mut(), env.clone(), info.clone(), unbond_msg).unwrap();
         set_delegation(&mut deps.querier, 460, "ustake");
 
         // ensure claims are proper
@@ -861,7 +861,7 @@ mod tests {
         // bob cannot exercise claims without enough balance
         let claim_ready = later(&env, (DAY * 3 + HOUR).unwrap());
         let too_soon = later(&env, DAY);
-        let fail = handle(
+        let fail = execute(
             deps.as_mut(),
             claim_ready.clone(),
             info.clone(),
@@ -872,11 +872,11 @@ mod tests {
         // provide the balance, but claim not yet mature - also prohibited
         deps.querier
             .update_balance(MOCK_CONTRACT_ADDR, coins(540, "ustake"));
-        let fail = handle(deps.as_mut(), too_soon, info.clone(), HandleMsg::Claim {});
+        let fail = execute(deps.as_mut(), too_soon, info.clone(), HandleMsg::Claim {});
         assert!(fail.is_err(), "{:?}", fail);
 
         // this should work with cash and claims ready
-        let res = handle(
+        let res = execute(
             deps.as_mut(),
             claim_ready,
             info.clone(),
@@ -915,7 +915,7 @@ mod tests {
 
         // bond some tokens to create a balance
         let info = mock_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
-        handle(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
+        execute(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
 
         // bob got 1000 DRV for 1000 stake at a 1.0 ratio
         assert_eq!(get_balance(deps.as_ref(), &bob), Uint128(1000));
@@ -926,7 +926,7 @@ mod tests {
             recipient: carl.clone(),
             amount: Uint128(200),
         };
-        handle(deps.as_mut(), mock_env(), bob_info.clone(), transfer).unwrap();
+        execute(deps.as_mut(), mock_env(), bob_info.clone(), transfer).unwrap();
         assert_eq!(get_balance(deps.as_ref(), &bob), Uint128(800));
         assert_eq!(get_balance(deps.as_ref(), &carl), Uint128(200));
 
@@ -936,7 +936,7 @@ mod tests {
             amount: Uint128(350),
             expires: None,
         };
-        handle(deps.as_mut(), mock_env(), bob_info.clone(), allow).unwrap();
+        execute(deps.as_mut(), mock_env(), bob_info.clone(), allow).unwrap();
         assert_eq!(get_balance(deps.as_ref(), &bob), Uint128(800));
         assert_eq!(get_balance(deps.as_ref(), &alice), Uint128(0));
         assert_eq!(
@@ -953,7 +953,7 @@ mod tests {
             amount: Uint128(250),
         };
         let alice_info = mock_info(&alice, &[]);
-        handle(deps.as_mut(), mock_env(), alice_info.clone(), self_pay).unwrap();
+        execute(deps.as_mut(), mock_env(), alice_info.clone(), self_pay).unwrap();
         assert_eq!(get_balance(deps.as_ref(), &bob), Uint128(550));
         assert_eq!(get_balance(deps.as_ref(), &alice), Uint128(250));
         assert_eq!(
@@ -967,13 +967,13 @@ mod tests {
         let burn_too_much = HandleMsg::Burn {
             amount: Uint128(1000),
         };
-        let failed = handle(deps.as_mut(), mock_env(), bob_info.clone(), burn_too_much);
+        let failed = execute(deps.as_mut(), mock_env(), bob_info.clone(), burn_too_much);
         assert!(failed.is_err());
         assert_eq!(get_balance(deps.as_ref(), &bob), Uint128(550));
         let burn = HandleMsg::Burn {
             amount: Uint128(130),
         };
-        handle(deps.as_mut(), mock_env(), bob_info.clone(), burn).unwrap();
+        execute(deps.as_mut(), mock_env(), bob_info.clone(), burn).unwrap();
         assert_eq!(get_balance(deps.as_ref(), &bob), Uint128(420));
     }
 }

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -22,13 +22,13 @@ cw0 = { path = "../../packages/cw0", version = "0.5.0" }
 cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw3 = { path = "../../packages/cw3", version = "0.5.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.5.0", features = ["iterator"] }
-cosmwasm-std = { version = "0.13.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }
 cw20 = { path = "../../packages/cw20", version = "0.5.0" }
 cw20-base = { path = "../cw20-base", version = "0.5.0", features = ["library"] }
 cw-multi-test = { path = "../../packages/multi-test", version = "0.5.0" }

--- a/contracts/cw3-fixed-multisig/schema/handle_msg.json
+++ b/contracts/cw3-fixed-multisig/schema/handle_msg.json
@@ -112,8 +112,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -123,7 +125,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -132,9 +133,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -265,8 +263,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -290,6 +290,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -313,6 +314,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -343,6 +345,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -384,9 +387,10 @@
       ]
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -404,7 +408,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -422,7 +426,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -432,6 +436,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -442,11 +447,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -461,6 +463,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -91,7 +91,7 @@ pub fn handle_propose(
     let raw_sender = deps.api.canonical_address(&info.sender)?;
     let vote_power = VOTERS
         .may_load(deps.storage, &raw_sender)?
-        .ok_or_else(|| ContractError::Unauthorized {})?;
+        .ok_or(ContractError::Unauthorized {})?;
 
     let cfg = CONFIG.load(deps.storage)?;
 
@@ -155,7 +155,7 @@ pub fn handle_vote(
     let raw_sender = deps.api.canonical_address(&info.sender)?;
     let vote_power = VOTERS
         .may_load(deps.storage, &raw_sender)?
-        .ok_or_else(|| ContractError::Unauthorized {})?;
+        .ok_or(ContractError::Unauthorized {})?;
 
     // ensure proposal exists and can be voted on
     let mut prop = PROPOSALS.load(deps.storage, proposal_id.into())?;

--- a/contracts/cw3-fixed-multisig/src/integration_tests.rs
+++ b/contracts/cw3-fixed-multisig/src/integration_tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::contract::{handle, init, query};
+use crate::contract::{execute, init, query};
 use crate::msg::{HandleMsg, InitMsg, Voter};
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
 use cosmwasm_std::{from_binary, to_binary, HumanAddr, Uint128, WasmMsg, WasmQuery};
@@ -19,13 +19,13 @@ fn mock_app() -> App {
 }
 
 pub fn contract_cw3_fixed_multisig() -> Box<dyn Contract> {
-    let contract = ContractWrapper::new(handle, init, query);
+    let contract = ContractWrapper::new(execute, init, query);
     Box::new(contract)
 }
 
 pub fn contract_cw20() -> Box<dyn Contract> {
     let contract = ContractWrapper::new(
-        cw20_base::contract::handle,
+        cw20_base::contract::execute,
         cw20_base::contract::init,
         cw20_base::contract::query,
     );

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -23,12 +23,12 @@ cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw3 = { path = "../../packages/cw3", version = "0.5.0" }
 cw4 = { path = "../../packages/cw4", version = "0.5.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.5.0", features = ["iterator"] }
-cosmwasm-std = { version = "0.13.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.14.0-alpha2", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }
 cw4-group = { path = "../cw4-group", version = "0.5.0" }
 cw-multi-test = { path = "../../packages/multi-test", version = "0.5.0" }

--- a/contracts/cw3-flex-multisig/schema/handle_msg.json
+++ b/contracts/cw3-flex-multisig/schema/handle_msg.json
@@ -124,8 +124,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -135,7 +137,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -144,9 +145,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -320,8 +318,10 @@
       }
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -345,6 +345,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -368,6 +369,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -398,6 +400,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -439,9 +442,10 @@
       ]
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -459,7 +463,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -477,7 +481,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -487,6 +491,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -497,11 +502,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -516,6 +518,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -53,7 +53,7 @@ pub fn init(
     Ok(Response::default())
 }
 
-pub fn handle(
+pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -65,17 +65,17 @@ pub fn handle(
             description,
             msgs,
             latest,
-        } => handle_propose(deps, env, info, title, description, msgs, latest),
-        HandleMsg::Vote { proposal_id, vote } => handle_vote(deps, env, info, proposal_id, vote),
-        HandleMsg::Execute { proposal_id } => handle_execute(deps, env, info, proposal_id),
-        HandleMsg::Close { proposal_id } => handle_close(deps, env, info, proposal_id),
+        } => execute_propose(deps, env, info, title, description, msgs, latest),
+        HandleMsg::Vote { proposal_id, vote } => execute_vote(deps, env, info, proposal_id, vote),
+        HandleMsg::Execute { proposal_id } => execute_execute(deps, env, info, proposal_id),
+        HandleMsg::Close { proposal_id } => execute_close(deps, env, info, proposal_id),
         HandleMsg::MemberChangedHook(MemberChangedHookMsg { diffs }) => {
-            handle_membership_hook(deps, env, info, diffs)
+            execute_membership_hook(deps, env, info, diffs)
         }
     }
 }
 
-pub fn handle_propose(
+pub fn execute_propose(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -140,7 +140,7 @@ pub fn handle_propose(
     })
 }
 
-pub fn handle_vote(
+pub fn execute_vote(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -197,7 +197,7 @@ pub fn handle_vote(
     })
 }
 
-pub fn handle_execute(
+pub fn execute_execute(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
@@ -229,7 +229,7 @@ pub fn handle_execute(
     })
 }
 
-pub fn handle_close(
+pub fn execute_close(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -264,7 +264,7 @@ pub fn handle_close(
     })
 }
 
-pub fn handle_membership_hook(
+pub fn execute_membership_hook(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
@@ -477,7 +477,7 @@ mod tests {
 
     pub fn contract_flex() -> Box<dyn Contract> {
         let contract = ContractWrapper::new(
-            crate::contract::handle,
+            crate::contract::execute,
             crate::contract::init,
             crate::contract::query,
         );
@@ -486,7 +486,7 @@ mod tests {
 
     pub fn contract_group() -> Box<dyn Contract> {
         let contract = ContractWrapper::new(
-            cw4_group::contract::handle,
+            cw4_group::contract::execute,
             cw4_group::contract::init,
             cw4_group::contract::query,
         );
@@ -1175,7 +1175,7 @@ mod tests {
 
     // uses the power from the beginning of the voting period
     #[test]
-    fn handle_group_changes_from_external() {
+    fn execute_group_changes_from_external() {
         let mut app = mock_app();
 
         let required_weight = 4;
@@ -1304,7 +1304,7 @@ mod tests {
     // similar to above - simpler case, but shows that one proposals can
     // trigger the action
     #[test]
-    fn handle_group_changes_from_proposal() {
+    fn execute_group_changes_from_proposal() {
         let mut app = mock_app();
 
         let required_weight = 4;

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -92,7 +92,7 @@ pub fn handle_propose(
     let vote_power = cfg
         .group_addr
         .is_member(&deps.querier, &raw_sender)?
-        .ok_or_else(|| ContractError::Unauthorized {})?;
+        .ok_or(ContractError::Unauthorized {})?;
 
     // max expires also used as default
     let max_expires = cfg.max_voting_period.after(&env.block);
@@ -164,7 +164,7 @@ pub fn handle_vote(
     let vote_power = cfg
         .group_addr
         .member_at_height(&deps.querier, info.sender.clone(), prop.start_height)?
-        .ok_or_else(|| ContractError::Unauthorized {})?;
+        .ok_or(ContractError::Unauthorized {})?;
 
     // cast vote if no vote previously cast
     BALLOTS.update(

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -31,10 +31,10 @@ cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw4 = { path = "../../packages/cw4", version = "0.5.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.5.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.5.0", features = ["iterator"] }
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    attr, to_binary, Binary, CanonicalAddr, Deps, DepsMut, Env, HandleResponse, HumanAddr,
-    InitResponse, MessageInfo, Order, StdResult,
+    attr, to_binary, Binary, CanonicalAddr, Deps, DepsMut, Env, HumanAddr, MessageInfo, Order,
+    Response, StdResult,
 };
 use cw0::maybe_canonical;
 use cw2::set_contract_version;
@@ -25,10 +25,10 @@ pub fn init(
     env: Env,
     _info: MessageInfo,
     msg: InitMsg,
-) -> Result<InitResponse, ContractError> {
+) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     create(deps, msg.admin, msg.members, env.block.height)?;
-    Ok(InitResponse::default())
+    Ok(Response::default())
 }
 
 // create is the init logic with set_contract_version removed so it can more
@@ -58,7 +58,7 @@ pub fn handle(
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
-) -> Result<HandleResponse, ContractError> {
+) -> Result<Response, ContractError> {
     match msg {
         HandleMsg::UpdateAdmin { admin } => Ok(ADMIN.handle_update_admin(deps, info, admin)?),
         HandleMsg::UpdateMembers { add, remove } => {
@@ -75,7 +75,7 @@ pub fn handle_update_members(
     info: MessageInfo,
     add: Vec<Member>,
     remove: Vec<HumanAddr>,
-) -> Result<HandleResponse, ContractError> {
+) -> Result<Response, ContractError> {
     let attributes = vec![
         attr("action", "update_members"),
         attr("added", add.len()),
@@ -87,7 +87,8 @@ pub fn handle_update_members(
     let diff = update_members(deps.branch(), env.block.height, info.sender, add, remove)?;
     // call all registered hooks
     let messages = HOOKS.prepare_hooks(deps.storage, |h| diff.clone().into_cosmos_msg(h))?;
-    Ok(HandleResponse {
+    Ok(Response {
+        submessages: vec![],
         messages,
         attributes,
         data: None,

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -31,10 +31,10 @@ cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw4 = { path = "../../packages/cw4", version = "0.5.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.5.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.5.0", features = ["iterator"] }
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -48,23 +48,23 @@ pub fn init(
 }
 
 // And declare a custom Error variant for the ones where you will want to make use of it
-pub fn handle(
+pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        HandleMsg::UpdateAdmin { admin } => Ok(ADMIN.handle_update_admin(deps, info, admin)?),
-        HandleMsg::AddHook { addr } => Ok(HOOKS.handle_add_hook(&ADMIN, deps, info, addr)?),
-        HandleMsg::RemoveHook { addr } => Ok(HOOKS.handle_remove_hook(&ADMIN, deps, info, addr)?),
-        HandleMsg::Bond {} => handle_bond(deps, env, info),
-        HandleMsg::Unbond { tokens: amount } => handle_unbond(deps, env, info, amount),
-        HandleMsg::Claim {} => handle_claim(deps, env, info),
+        HandleMsg::UpdateAdmin { admin } => Ok(ADMIN.execute_update_admin(deps, info, admin)?),
+        HandleMsg::AddHook { addr } => Ok(HOOKS.execute_add_hook(&ADMIN, deps, info, addr)?),
+        HandleMsg::RemoveHook { addr } => Ok(HOOKS.execute_remove_hook(&ADMIN, deps, info, addr)?),
+        HandleMsg::Bond {} => execute_bond(deps, env, info),
+        HandleMsg::Unbond { tokens: amount } => execute_unbond(deps, env, info, amount),
+        HandleMsg::Claim {} => execute_claim(deps, env, info),
     }
 }
 
-pub fn handle_bond(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+pub fn execute_bond(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
 
     // ensure the sent denom was proper
@@ -113,7 +113,7 @@ pub fn handle_bond(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Respons
     })
 }
 
-pub fn handle_unbond(
+pub fn execute_unbond(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -199,7 +199,11 @@ fn calc_weight(stake: Uint128, cfg: &Config) -> Option<u64> {
     }
 }
 
-pub fn handle_claim(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+pub fn execute_claim(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
     let sender_raw = deps.api.canonical_address(&info.sender)?;
     let release = CLAIMS.claim_tokens(deps.storage, &sender_raw, &env.block, None)?;
     if release.is_zero() {
@@ -362,7 +366,7 @@ mod tests {
             if *stake != 0 {
                 let msg = HandleMsg::Bond {};
                 let info = mock_info(HumanAddr::from(*addr), &coins(*stake, DENOM));
-                handle(deps.branch(), env.clone(), info, msg).unwrap();
+                execute(deps.branch(), env.clone(), info, msg).unwrap();
             }
         }
     }
@@ -377,7 +381,7 @@ mod tests {
                     tokens: Uint128(*stake),
                 };
                 let info = mock_info(HumanAddr::from(*addr), &[]);
-                handle(deps.branch(), env.clone(), info, msg).unwrap();
+                execute(deps.branch(), env.clone(), info, msg).unwrap();
             }
         }
     }
@@ -515,7 +519,7 @@ mod tests {
         let mut env = mock_env();
         env.block.height += 5;
         let info = mock_info(USER2, &[]);
-        let err = handle(deps.as_mut(), env, info, msg).unwrap_err();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
         match err {
             ContractError::Std(StdError::Underflow {
                 minuend,
@@ -547,7 +551,7 @@ mod tests {
         let member2: u64 = from_slice(&member2_raw).unwrap();
         assert_eq!(6, member2);
 
-        // and handle misses
+        // and execute misses
         let member3_canon = deps.api.canonical_address(&USER3.into()).unwrap();
         let member3_raw = deps.storage.get(&member_key(&member3_canon));
         assert_eq!(None, member3_raw);
@@ -601,7 +605,7 @@ mod tests {
         );
 
         // nothing can be withdrawn yet
-        let err = handle(
+        let err = execute(
             deps.as_mut(),
             env2.clone(),
             mock_info(USER1, &[]),
@@ -614,7 +618,7 @@ mod tests {
         let mut env3 = mock_env();
         env3.block.height += 2 + UNBONDING_BLOCKS;
         // first one can now release
-        let res = handle(
+        let res = execute(
             deps.as_mut(),
             env3.clone(),
             mock_info(USER1, &[]),
@@ -631,7 +635,7 @@ mod tests {
         );
 
         // second releases partially
-        let res = handle(
+        let res = execute(
             deps.as_mut(),
             env3.clone(),
             mock_info(USER2, &[]),
@@ -648,7 +652,7 @@ mod tests {
         );
 
         // but the third one cannot release
-        let err = handle(
+        let err = execute(
             deps.as_mut(),
             env3.clone(),
             mock_info(USER3, &[]),
@@ -675,7 +679,7 @@ mod tests {
         // ensure second can claim all tokens at once
         let mut env4 = mock_env();
         env4.block.height += 55 + UNBONDING_BLOCKS + UNBONDING_BLOCKS;
-        let res = handle(
+        let res = execute(
             deps.as_mut(),
             env4.clone(),
             mock_info(USER2, &[]),
@@ -712,7 +716,7 @@ mod tests {
 
         // non-admin cannot add hook
         let user_info = mock_info(USER1, &[]);
-        let err = handle(
+        let err = execute(
             deps.as_mut(),
             mock_env(),
             user_info.clone(),
@@ -723,7 +727,7 @@ mod tests {
 
         // admin can add it, and it appears in the query
         let admin_info = mock_info(INIT_ADMIN, &[]);
-        let _ = handle(
+        let _ = execute(
             deps.as_mut(),
             mock_env(),
             admin_info.clone(),
@@ -737,7 +741,7 @@ mod tests {
         let remove_msg = HandleMsg::RemoveHook {
             addr: contract2.clone(),
         };
-        let err = handle(
+        let err = execute(
             deps.as_mut(),
             mock_env(),
             admin_info.clone(),
@@ -750,12 +754,12 @@ mod tests {
         let add_msg2 = HandleMsg::AddHook {
             addr: contract2.clone(),
         };
-        let _ = handle(deps.as_mut(), mock_env(), admin_info.clone(), add_msg2).unwrap();
+        let _ = execute(deps.as_mut(), mock_env(), admin_info.clone(), add_msg2).unwrap();
         let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
         assert_eq!(hooks.hooks, vec![contract1.clone(), contract2.clone()]);
 
         // cannot re-add an existing contract
-        let err = handle(
+        let err = execute(
             deps.as_mut(),
             mock_env(),
             admin_info.clone(),
@@ -768,7 +772,7 @@ mod tests {
         let remove_msg = HandleMsg::RemoveHook {
             addr: contract1.clone(),
         };
-        let err = handle(
+        let err = execute(
             deps.as_mut(),
             mock_env(),
             user_info.clone(),
@@ -778,7 +782,7 @@ mod tests {
         assert_eq!(err, HookError::Admin(AdminError::NotAdmin {}).into());
 
         // remove the original
-        let _ = handle(
+        let _ = execute(
             deps.as_mut(),
             mock_env(),
             admin_info.clone(),
@@ -809,13 +813,13 @@ mod tests {
             addr: contract2.clone(),
         };
         for msg in vec![add_msg, add_msg2] {
-            let _ = handle(deps.as_mut(), mock_env(), admin_info.clone(), msg).unwrap();
+            let _ = execute(deps.as_mut(), mock_env(), admin_info.clone(), msg).unwrap();
         }
 
         // check firing on bond
         assert_users(deps.as_ref(), None, None, None, None);
         let info = mock_info(USER1, &coins(13_800, DENOM));
-        let res = handle(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
         assert_users(deps.as_ref(), Some(13), None, None, None);
 
         // ensure messages for each of the 2 hooks
@@ -831,7 +835,7 @@ mod tests {
             tokens: Uint128(7_300),
         };
         let info = mock_info(USER1, &[]);
-        let res = handle(deps.as_mut(), mock_env(), info, msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_users(deps.as_ref(), Some(6), None, None, None);
 
         // ensure messages for each of the 2 hooks
@@ -850,12 +854,12 @@ mod tests {
 
         // cannot bond with 0 coins
         let info = mock_info(HumanAddr::from(USER1), &[]);
-        let err = handle(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap_err();
         assert_eq!(err, ContractError::NoFunds {});
 
         // cannot bond with incorrect denom
         let info = mock_info(HumanAddr::from(USER1), &[coin(500, "FOO")]);
-        let err = handle(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap_err();
         assert_eq!(err, ContractError::MissingDenom(DENOM.to_string()));
 
         // cannot bond with 2 coins (even if one is correct)
@@ -863,13 +867,13 @@ mod tests {
             HumanAddr::from(USER1),
             &[coin(1234, DENOM), coin(5000, "BAR")],
         );
-        let err = handle(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap_err();
         assert_eq!(err, ContractError::ExtraDenoms(DENOM.to_string()));
 
         // can bond with just the proper denom
         // cannot bond with incorrect denom
         let info = mock_info(HumanAddr::from(USER1), &[coin(500, DENOM)]);
-        handle(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
+        execute(deps.as_mut(), mock_env(), info, HandleMsg::Bond {}).unwrap();
     }
 
     #[test]

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -29,10 +29,10 @@ cw0 = { path = "../../packages/cw0", version = "0.5.0" }
 cw2 = { path = "../../packages/cw2", version = "0.5.0" }
 cw721 = { path = "../../packages/cw721", version = "0.5.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.5.0" , features = ["iterator"]}
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/contracts/cw721-base/src/contract.rs
+++ b/contracts/cw721-base/src/contract.rs
@@ -34,39 +34,39 @@ pub fn init(deps: DepsMut, _env: Env, _info: MessageInfo, msg: InitMsg) -> StdRe
     Ok(Response::default())
 }
 
-pub fn handle(
+pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        HandleMsg::Mint(msg) => handle_mint(deps, env, info, msg),
+        HandleMsg::Mint(msg) => execute_mint(deps, env, info, msg),
         HandleMsg::Approve {
             spender,
             token_id,
             expires,
-        } => handle_approve(deps, env, info, spender, token_id, expires),
+        } => execute_approve(deps, env, info, spender, token_id, expires),
         HandleMsg::Revoke { spender, token_id } => {
-            handle_revoke(deps, env, info, spender, token_id)
+            execute_revoke(deps, env, info, spender, token_id)
         }
         HandleMsg::ApproveAll { operator, expires } => {
-            handle_approve_all(deps, env, info, operator, expires)
+            execute_approve_all(deps, env, info, operator, expires)
         }
-        HandleMsg::RevokeAll { operator } => handle_revoke_all(deps, env, info, operator),
+        HandleMsg::RevokeAll { operator } => execute_revoke_all(deps, env, info, operator),
         HandleMsg::TransferNft {
             recipient,
             token_id,
-        } => handle_transfer_nft(deps, env, info, recipient, token_id),
+        } => execute_transfer_nft(deps, env, info, recipient, token_id),
         HandleMsg::SendNft {
             contract,
             token_id,
             msg,
-        } => handle_send_nft(deps, env, info, contract, token_id, msg),
+        } => execute_send_nft(deps, env, info, contract, token_id, msg),
     }
 }
 
-pub fn handle_mint(
+pub fn execute_mint(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
@@ -106,7 +106,7 @@ pub fn handle_mint(
     })
 }
 
-pub fn handle_transfer_nft(
+pub fn execute_transfer_nft(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -128,7 +128,7 @@ pub fn handle_transfer_nft(
     })
 }
 
-pub fn handle_send_nft(
+pub fn execute_send_nft(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -176,7 +176,7 @@ pub fn _transfer_nft(
     Ok(token)
 }
 
-pub fn handle_approve(
+pub fn execute_approve(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -199,7 +199,7 @@ pub fn handle_approve(
     })
 }
 
-pub fn handle_revoke(
+pub fn execute_revoke(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -262,7 +262,7 @@ pub fn _update_approvals(
     Ok(token)
 }
 
-pub fn handle_approve_all(
+pub fn execute_approve_all(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
@@ -292,7 +292,7 @@ pub fn handle_approve_all(
     })
 }
 
-pub fn handle_revoke_all(
+pub fn execute_revoke_all(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
@@ -655,7 +655,7 @@ mod tests {
 
         // random cannot mint
         let random = mock_info("random", &[]);
-        let err = handle(deps.as_mut(), mock_env(), random, mint_msg.clone()).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), random, mint_msg.clone()).unwrap_err();
         match err {
             ContractError::Unauthorized {} => {}
             e => panic!("unexpected error: {}", e),
@@ -663,7 +663,7 @@ mod tests {
 
         // minter can mint
         let allowed = mock_info(MINTER, &[]);
-        let _ = handle(deps.as_mut(), mock_env(), allowed, mint_msg.clone()).unwrap();
+        let _ = execute(deps.as_mut(), mock_env(), allowed, mint_msg.clone()).unwrap();
 
         // ensure num tokens increases
         let count = query_num_tokens(deps.as_ref()).unwrap();
@@ -703,7 +703,7 @@ mod tests {
         });
 
         let allowed = mock_info(MINTER, &[]);
-        let err = handle(deps.as_mut(), mock_env(), allowed, mint_msg2).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), allowed, mint_msg2).unwrap_err();
         match err {
             ContractError::Claimed {} => {}
             e => panic!("unexpected error: {}", e),
@@ -734,7 +734,7 @@ mod tests {
         });
 
         let minter = mock_info(MINTER, &[]);
-        handle(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
 
         // random cannot transfer
         let random = mock_info("random", &[]);
@@ -743,7 +743,7 @@ mod tests {
             token_id: token_id.clone(),
         };
 
-        let err = handle(deps.as_mut(), mock_env(), random, transfer_msg.clone()).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), random, transfer_msg.clone()).unwrap_err();
 
         match err {
             ContractError::Unauthorized {} => {}
@@ -757,7 +757,7 @@ mod tests {
             token_id: token_id.clone(),
         };
 
-        let res = handle(deps.as_mut(), mock_env(), random, transfer_msg.clone()).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), random, transfer_msg.clone()).unwrap();
 
         assert_eq!(
             res,
@@ -794,7 +794,7 @@ mod tests {
         });
 
         let minter = mock_info(MINTER, &[]);
-        handle(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
 
         let msg = to_binary("You now have the melting power").unwrap();
         let target = HumanAddr::from("another_contract");
@@ -805,7 +805,7 @@ mod tests {
         };
 
         let random = mock_info("random", &[]);
-        let err = handle(deps.as_mut(), mock_env(), random, send_msg.clone()).unwrap_err();
+        let err = execute(deps.as_mut(), mock_env(), random, send_msg.clone()).unwrap_err();
         match err {
             ContractError::Unauthorized {} => {}
             e => panic!("unexpected error: {}", e),
@@ -813,7 +813,7 @@ mod tests {
 
         // but owner can
         let random = mock_info("venus", &[]);
-        let res = handle(deps.as_mut(), mock_env(), random, send_msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), random, send_msg).unwrap();
 
         let payload = Cw721ReceiveMsg {
             sender: "venus".into(),
@@ -864,7 +864,7 @@ mod tests {
         });
 
         let minter = mock_info(MINTER, &[]);
-        handle(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
 
         // Give random transferring power
         let approve_msg = HandleMsg::Approve {
@@ -873,7 +873,7 @@ mod tests {
             expires: None,
         };
         let owner = mock_info("demeter", &[]);
-        let res = handle(deps.as_mut(), mock_env(), owner, approve_msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), owner, approve_msg).unwrap();
         assert_eq!(
             res,
             Response {
@@ -895,7 +895,7 @@ mod tests {
             recipient: "person".into(),
             token_id: token_id.clone(),
         };
-        handle(deps.as_mut(), mock_env(), random, transfer_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), random, transfer_msg).unwrap();
 
         // Approvals are removed / cleared
         let query_msg = QueryMsg::OwnerOf {
@@ -919,13 +919,13 @@ mod tests {
             expires: None,
         };
         let owner = mock_info("person", &[]);
-        handle(deps.as_mut(), mock_env(), owner.clone(), approve_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), owner.clone(), approve_msg).unwrap();
 
         let revoke_msg = HandleMsg::Revoke {
             spender: "random".into(),
             token_id: token_id.clone(),
         };
-        handle(deps.as_mut(), mock_env(), owner, revoke_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), owner, revoke_msg).unwrap();
 
         // Approvals are now removed / cleared
         let res: OwnerOfResponse =
@@ -961,7 +961,7 @@ mod tests {
         });
 
         let minter = mock_info(MINTER, &[]);
-        handle(deps.as_mut(), mock_env(), minter.clone(), mint_msg1).unwrap();
+        execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg1).unwrap();
 
         let mint_msg2 = HandleMsg::Mint(MintMsg {
             token_id: token_id2.clone(),
@@ -971,7 +971,7 @@ mod tests {
             image: None,
         });
 
-        handle(deps.as_mut(), mock_env(), minter, mint_msg2).unwrap();
+        execute(deps.as_mut(), mock_env(), minter, mint_msg2).unwrap();
 
         // paginate the token_ids
         let tokens = query_all_tokens(deps.as_ref(), None, Some(1)).unwrap();
@@ -987,7 +987,7 @@ mod tests {
             expires: None,
         };
         let owner = mock_info("demeter", &[]);
-        let res = handle(deps.as_mut(), mock_env(), owner, approve_all_msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), owner, approve_all_msg).unwrap();
         assert_eq!(
             res,
             Response {
@@ -1008,7 +1008,7 @@ mod tests {
             recipient: "person".into(),
             token_id: token_id1.clone(),
         };
-        handle(deps.as_mut(), mock_env(), random.clone(), transfer_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), random.clone(), transfer_msg).unwrap();
 
         // random can now send
         let inner_msg = WasmMsg::Execute {
@@ -1023,7 +1023,7 @@ mod tests {
             token_id: token_id2.clone(),
             msg: Some(to_binary(&msg).unwrap()),
         };
-        handle(deps.as_mut(), mock_env(), random, send_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), random, send_msg).unwrap();
 
         // Approve_all, revoke_all, and check for empty, to test revoke_all
         let approve_all_msg = HandleMsg::ApproveAll {
@@ -1032,7 +1032,7 @@ mod tests {
         };
         // person is now the owner of the tokens
         let owner = mock_info("person", &[]);
-        handle(deps.as_mut(), mock_env(), owner.clone(), approve_all_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), owner.clone(), approve_all_msg).unwrap();
 
         let res = query_all_approvals(deps.as_ref(), mock_env(), "person".into(), true, None, None)
             .unwrap();
@@ -1053,7 +1053,7 @@ mod tests {
             expires: Some(buddy_expires),
         };
         let owner = mock_info("person", &[]);
-        handle(deps.as_mut(), mock_env(), owner.clone(), approve_all_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), owner.clone(), approve_all_msg).unwrap();
 
         // and paginate queries
         let res = query_all_approvals(
@@ -1096,7 +1096,7 @@ mod tests {
         let revoke_all_msg = HandleMsg::RevokeAll {
             operator: "operator".into(),
         };
-        handle(deps.as_mut(), mock_env(), owner, revoke_all_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), owner, revoke_all_msg).unwrap();
 
         // Approvals are removed / cleared without affecting others
         let res = query_all_approvals(
@@ -1146,7 +1146,7 @@ mod tests {
             description: Some("Allows the owner the power to grow anything".to_string()),
             image: None,
         });
-        handle(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
 
         let mint_msg = HandleMsg::Mint(MintMsg {
             token_id: token_id2.clone(),
@@ -1157,7 +1157,7 @@ mod tests {
             ),
             image: None,
         });
-        handle(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
 
         let mint_msg = HandleMsg::Mint(MintMsg {
             token_id: token_id3.clone(),
@@ -1166,7 +1166,7 @@ mod tests {
             description: Some("Calm even the most excited children".to_string()),
             image: None,
         });
-        handle(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
+        execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
 
         // get all tokens in order:
         let expected = vec![token_id1.clone(), token_id2.clone(), token_id3.clone()];

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 cw0 = { path = "../cw0", version = "0.5.0" }
 cw-storage-plus = { path = "../storage-plus", version = "0.5.0", features = ["iterator"] }
 schemars = "0.7"

--- a/packages/controllers/src/admin.rs
+++ b/packages/controllers/src/admin.rs
@@ -66,7 +66,7 @@ impl<'a> Admin<'a> {
         }
     }
 
-    pub fn handle_update_admin(
+    pub fn execute_update_admin(
         &self,
         deps: DepsMut,
         info: MessageInfo,
@@ -150,7 +150,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_query() {
+    fn test_execute_query() {
         let mut deps = mock_dependencies(&[]);
 
         // initial setup
@@ -168,14 +168,14 @@ mod tests {
         let info = mock_info(&imposter, &[]);
         let new_admin = Some(friend.clone());
         let err = control
-            .handle_update_admin(deps.as_mut(), info, new_admin.clone())
+            .execute_update_admin(deps.as_mut(), info, new_admin.clone())
             .unwrap_err();
         assert_eq!(AdminError::NotAdmin {}, err);
 
         // owner can update
         let info = mock_info(&owner, &[]);
         let res = control
-            .handle_update_admin(deps.as_mut(), info, new_admin)
+            .execute_update_admin(deps.as_mut(), info, new_admin)
             .unwrap();
         assert_eq!(0, res.messages.len());
 

--- a/packages/controllers/src/admin.rs
+++ b/packages/controllers/src/admin.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use cosmwasm_std::{
-    attr, CanonicalAddr, Deps, DepsMut, HandleResponse, HumanAddr, MessageInfo, StdError, StdResult,
+    attr, CanonicalAddr, Deps, DepsMut, HumanAddr, MessageInfo, Response, StdError, StdResult,
 };
 use cw0::maybe_canonical;
 use cw_storage_plus::Item;
@@ -71,7 +71,7 @@ impl<'a> Admin<'a> {
         deps: DepsMut,
         info: MessageInfo,
         new_admin: Option<HumanAddr>,
-    ) -> Result<HandleResponse, AdminError> {
+    ) -> Result<Response, AdminError> {
         self.assert_admin(deps.as_ref(), &info.sender)?;
 
         let admin_str = match new_admin.as_ref() {
@@ -86,7 +86,8 @@ impl<'a> Admin<'a> {
 
         self.set(deps, new_admin)?;
 
-        Ok(HandleResponse {
+        Ok(Response {
+            submessages: vec![],
             messages: vec![],
             attributes,
             data: None,

--- a/packages/controllers/src/hooks.rs
+++ b/packages/controllers/src/hooks.rs
@@ -72,7 +72,7 @@ impl<'a> Hooks<'a> {
             .collect()
     }
 
-    pub fn handle_add_hook(
+    pub fn execute_add_hook(
         &self,
         admin: &Admin,
         deps: DepsMut,
@@ -95,7 +95,7 @@ impl<'a> Hooks<'a> {
         })
     }
 
-    pub fn handle_remove_hook(
+    pub fn execute_remove_hook(
         &self,
         admin: &Admin,
         deps: DepsMut,

--- a/packages/controllers/src/hooks.rs
+++ b/packages/controllers/src/hooks.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use cosmwasm_std::{
-    attr, CosmosMsg, Deps, DepsMut, HandleResponse, HumanAddr, MessageInfo, StdError, StdResult,
-    Storage,
+    attr, CosmosMsg, Deps, DepsMut, HumanAddr, MessageInfo, Response, StdError, StdResult, Storage,
 };
 use cw_storage_plus::Item;
 
@@ -79,7 +78,7 @@ impl<'a> Hooks<'a> {
         deps: DepsMut,
         info: MessageInfo,
         addr: HumanAddr,
-    ) -> Result<HandleResponse, HookError> {
+    ) -> Result<Response, HookError> {
         admin.assert_admin(deps.as_ref(), &info.sender)?;
         self.add_hook(deps.storage, addr.clone())?;
 
@@ -88,7 +87,8 @@ impl<'a> Hooks<'a> {
             attr("hook", addr),
             attr("sender", info.sender),
         ];
-        Ok(HandleResponse {
+        Ok(Response {
+            submessages: vec![],
             messages: vec![],
             attributes,
             data: None,
@@ -101,7 +101,7 @@ impl<'a> Hooks<'a> {
         deps: DepsMut,
         info: MessageInfo,
         addr: HumanAddr,
-    ) -> Result<HandleResponse, HookError> {
+    ) -> Result<Response, HookError> {
         admin.assert_admin(deps.as_ref(), &info.sender)?;
         self.remove_hook(deps.storage, addr.clone())?;
 
@@ -110,7 +110,8 @@ impl<'a> Hooks<'a> {
             attr("hook", addr),
             attr("sender", info.sender),
         ];
-        Ok(HandleResponse {
+        Ok(Response {
+            submessages: vec![],
             messages: vec![],
             attributes,
             data: None,

--- a/packages/cw0/Cargo.toml
+++ b/packages/cw0/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }

--- a/packages/cw0/src/payment.rs
+++ b/packages/cw0/src/payment.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 /// returns an error if any coins were sent
 pub fn nonpayable(info: &MessageInfo) -> Result<(), PaymentError> {
-    if info.sent_funds.is_empty() {
+    if info.funds.is_empty() {
         Ok(())
     } else {
         Err(PaymentError::NonPayable {})
@@ -13,11 +13,11 @@ pub fn nonpayable(info: &MessageInfo) -> Result<(), PaymentError> {
 /// Requires exactly one denom sent, which matches the requested denom.
 /// Returns the amount if only one denom and non-zero amount. Errors otherwise.
 pub fn must_pay(info: &MessageInfo, denom: &str) -> Result<Uint128, PaymentError> {
-    match info.sent_funds.len() {
+    match info.funds.len() {
         0 => Err(PaymentError::NoFunds {}),
         1 => {
-            if info.sent_funds[0].denom == denom {
-                let payment = info.sent_funds[0].amount;
+            if info.funds[0].denom == denom {
+                let payment = info.funds[0].amount;
                 if payment.is_zero() {
                     Err(PaymentError::NoFunds {})
                 } else {
@@ -29,7 +29,7 @@ pub fn must_pay(info: &MessageInfo, denom: &str) -> Result<Uint128, PaymentError
         }
         _ => {
             // find first mis-match
-            let wrong = info.sent_funds.iter().find(|c| c.denom != denom).unwrap();
+            let wrong = info.funds.iter().find(|c| c.denom != denom).unwrap();
             Err(PaymentError::ExtraDenom(wrong.denom.to_string()))
         }
     }
@@ -38,13 +38,13 @@ pub fn must_pay(info: &MessageInfo, denom: &str) -> Result<Uint128, PaymentError
 /// Similar to must_pay, but it any payment is optional. Returns an error if a different
 /// denom was sent. Otherwise, returns the amount of `denom` sent, or 0 if nothing sent.
 pub fn may_pay(info: &MessageInfo, denom: &str) -> Result<Uint128, PaymentError> {
-    if info.sent_funds.is_empty() {
+    if info.funds.is_empty() {
         Ok(Uint128(0))
-    } else if info.sent_funds.len() == 1 && info.sent_funds[0].denom == denom {
-        Ok(info.sent_funds[0].amount)
+    } else if info.funds.len() == 1 && info.funds[0].denom == denom {
+        Ok(info.funds[0].amount)
     } else {
         // find first mis-match
-        let wrong = info.sent_funds.iter().find(|c| c.denom != denom).unwrap();
+        let wrong = info.funds.iter().find(|c| c.denom != denom).unwrap();
         Err(PaymentError::ExtraDenom(wrong.denom.to_string()))
     }
 }

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -10,9 +10,9 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/packages/cw1/schema/handle_msg.json
+++ b/packages/cw1/schema/handle_msg.json
@@ -28,8 +28,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -39,7 +41,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -48,9 +49,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -136,8 +134,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -161,6 +161,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -184,6 +185,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -214,6 +216,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -246,9 +249,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -266,7 +270,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -284,7 +288,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -294,6 +298,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -304,11 +309,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -323,6 +325,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/packages/cw1/schema/query_msg.json
+++ b/packages/cw1/schema/query_msg.json
@@ -29,8 +29,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -40,7 +42,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -49,9 +50,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -137,8 +135,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -162,6 +162,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -185,6 +186,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -215,6 +217,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -247,9 +250,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -267,7 +271,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -285,7 +289,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -295,6 +299,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -305,11 +310,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -324,6 +326,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.5.0" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/packages/cw20/src/query.rs
+++ b/packages/cw20/src/query.rs
@@ -68,7 +68,7 @@ pub struct MinterResponse {
     pub cap: Option<Uint128>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct AllowanceInfo {
     pub spender: HumanAddr,
     pub allowance: Uint128,

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/packages/cw3/schema/handle_msg.json
+++ b/packages/cw3/schema/handle_msg.json
@@ -122,8 +122,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -133,7 +135,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -142,9 +143,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -275,8 +273,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -300,6 +300,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -323,6 +324,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -353,6 +355,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -394,9 +397,10 @@
       ]
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -414,7 +418,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -432,7 +436,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -442,6 +446,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -452,11 +457,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -471,6 +473,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/packages/cw3/schema/proposal_list_response.json
+++ b/packages/cw3/schema/proposal_list_response.json
@@ -15,8 +15,10 @@
   },
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -26,7 +28,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -35,9 +36,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -218,8 +216,10 @@
       }
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -243,6 +243,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -266,6 +267,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -296,6 +298,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -427,9 +430,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -447,7 +451,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -465,7 +469,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -475,6 +479,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -485,11 +490,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -504,6 +506,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/packages/cw3/schema/proposal_response.json
+++ b/packages/cw3/schema/proposal_response.json
@@ -47,8 +47,10 @@
   },
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -58,7 +60,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -67,9 +68,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"
@@ -204,8 +202,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -229,6 +229,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -252,6 +253,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -282,6 +284,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -413,9 +416,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -433,7 +437,7 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "description": "msg is the json-encoded ExecuteMsg struct (as raw Binary)",
                   "allOf": [
                     {
                       "$ref": "#/definitions/Binary"
@@ -451,7 +455,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"
@@ -461,6 +465,7 @@
               "type": "object",
               "required": [
                 "code_id",
+                "label",
                 "msg",
                 "send"
               ],
@@ -471,11 +476,8 @@
                   "minimum": 0.0
                 },
                 "label": {
-                  "description": "optional human-readbale label for the contract",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "description": "A human-readbale label for the contract",
+                  "type": "string"
                 },
                 "msg": {
                   "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
@@ -490,6 +492,42 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
+          "type": "object",
+          "required": [
+            "migrate"
+          ],
+          "properties": {
+            "migrate": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "new_code_id"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded MigrateMsg struct that will be passed to the new code",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "new_code_id": {
+                  "description": "the code_id of the new logic to place in the given contract",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               }
             }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -10,9 +10,9 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/packages/cw4/src/helpers.rs
+++ b/packages/cw4/src/helpers.rs
@@ -63,12 +63,12 @@ impl Cw4Contract {
         .into())
     }
 
-    fn encode_raw_query<T: Into<Binary>>(&self, key: T) -> StdResult<QueryRequest<Empty>> {
-        Ok(WasmQuery::Raw {
+    fn encode_raw_query<T: Into<Binary>>(&self, key: T) -> QueryRequest<Empty> {
+        WasmQuery::Raw {
             contract_addr: self.addr(),
             key: key.into(),
         }
-        .into())
+        .into()
     }
 
     /// Show the hooks
@@ -80,7 +80,7 @@ impl Cw4Contract {
 
     /// Read the total weight
     pub fn total_weight(&self, querier: &QuerierWrapper) -> StdResult<u64> {
-        let query = self.encode_raw_query(TOTAL_KEY.as_bytes())?;
+        let query = self.encode_raw_query(TOTAL_KEY.as_bytes());
         querier.query(&query)
     }
 
@@ -91,7 +91,7 @@ impl Cw4Contract {
         addr: &CanonicalAddr,
     ) -> StdResult<Option<u64>> {
         let path = member_key(addr.as_slice());
-        let query = self.encode_raw_query(path)?;
+        let query = self.encode_raw_query(path);
 
         // We have to copy the logic of Querier.query to handle the empty case, and not
         // try to decode empty result into a u64.

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.13.2" }
+cosmwasm-schema = { version = "0.14.0-alpha2" }

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -16,6 +16,6 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.5.0" }
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -420,8 +420,8 @@ mod test {
         let poor = get_balance(&router, &rcpt);
         assert_eq!(vec![coin(10, "btc"), coin(30, "eth")], poor);
 
-        // cannot send from other account
-        router.execute(rcpt.clone(), msg).unwrap_err();
+        // can send from other account (but funds will be deducted from sender)
+        router.execute(rcpt.clone(), msg).unwrap();
 
         // cannot send too much
         let msg = BankMsg::Send {

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 use cosmwasm_std::testing::{mock_env, MockApi};
 use cosmwasm_std::{
     from_slice, to_binary, Api, Attribute, BankMsg, Binary, BlockInfo, Coin, ContractResult,
-    CosmosMsg, Empty, HandleResponse, HumanAddr, InitResponse, MessageInfo, Querier, QuerierResult,
-    QuerierWrapper, QueryRequest, SystemError, SystemResult, WasmMsg,
+    CosmosMsg, Empty, HumanAddr, MessageInfo, Querier, QuerierResult, QuerierWrapper, QueryRequest,
+    Response, SystemError, SystemResult, WasmMsg,
 };
 
 use crate::bank::{Bank, BankCache, BankOps, BankRouter};
@@ -17,7 +17,7 @@ pub struct AppResponse {
     pub data: Option<Binary>,
 }
 
-// This can be InitResponse, HandleResponse, MigrationResponse
+// This can be Response, Response, MigrationResponse
 #[derive(Default, Clone)]
 pub struct ActionResponse {
     // TODO: allow T != Empty
@@ -26,8 +26,8 @@ pub struct ActionResponse {
     pub data: Option<Binary>,
 }
 
-impl From<HandleResponse<Empty>> for ActionResponse {
-    fn from(input: HandleResponse<Empty>) -> Self {
+impl From<Response<Empty>> for ActionResponse {
+    fn from(input: Response<Empty>) -> Self {
         ActionResponse {
             messages: input.messages,
             attributes: input.attributes,
@@ -37,7 +37,7 @@ impl From<HandleResponse<Empty>> for ActionResponse {
 }
 
 impl ActionResponse {
-    fn init(input: InitResponse<Empty>, address: HumanAddr) -> Self {
+    fn init(input: Response<Empty>, address: HumanAddr) -> Self {
         ActionResponse {
             messages: input.messages,
             attributes: input.attributes,
@@ -149,7 +149,7 @@ impl App {
             code_id,
             msg: init_msg,
             send: send_funds.to_vec(),
-            label: Some(label.into()),
+            label: label.into(),
         }
         .into();
         let res = self.execute(sender.into(), msg)?;
@@ -302,7 +302,7 @@ impl<'a> AppCache<'a> {
                 // then call the contract
                 let info = MessageInfo {
                     sender,
-                    sent_funds: send,
+                    funds: send,
                 };
                 let res =
                     self.wasm
@@ -321,7 +321,7 @@ impl<'a> AppCache<'a> {
                 // then call the contract
                 let info = MessageInfo {
                     sender,
-                    sent_funds: send,
+                    funds: send,
                 };
                 let res = self
                     .wasm
@@ -330,6 +330,12 @@ impl<'a> AppCache<'a> {
                     contract_addr.clone(),
                     ActionResponse::init(res, contract_addr),
                 ))
+            }
+            WasmMsg::Migrate { .. } => {
+                unimplemented!()
+            }
+            m => {
+                panic!("Unsupported wasm message: {:?}", m)
             }
         }
     }
@@ -343,7 +349,6 @@ impl<'a> AppCache<'a> {
         if !amount.is_empty() {
             let sender: HumanAddr = sender.into();
             let msg = BankMsg::Send {
-                from_address: sender.clone(),
                 to_address: recipient.into(),
                 amount: amount.to_vec(),
             };
@@ -405,7 +410,6 @@ mod test {
         // send both tokens
         let to_send = vec![coin(30, "eth"), coin(5, "btc")];
         let msg: CosmosMsg = BankMsg::Send {
-            from_address: owner.clone(),
             to_address: rcpt.clone(),
             amount: to_send.clone(),
         }
@@ -421,7 +425,6 @@ mod test {
 
         // cannot send too much
         let msg = BankMsg::Send {
-            from_address: owner.clone(),
             to_address: rcpt.clone(),
             amount: coins(20, "btc"),
         }
@@ -575,7 +578,6 @@ mod test {
 
         // sending 7 eth works
         let msg = BankMsg::Send {
-            from_address: reflect_addr.clone(),
             to_address: random.clone(),
             amount: coins(7, "eth"),
         }
@@ -600,13 +602,11 @@ mod test {
 
         // sending 8 eth, then 3 btc should fail both
         let msg = BankMsg::Send {
-            from_address: reflect_addr.clone(),
             to_address: random.clone(),
             amount: coins(8, "eth"),
         }
         .into();
         let msg2 = BankMsg::Send {
-            from_address: reflect_addr.clone(),
             to_address: random.clone(),
             amount: coins(3, "btc"),
         }

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -139,16 +139,9 @@ impl Bank for SimpleBank {
         msg: BankMsg,
     ) -> Result<(), String> {
         match msg {
-            BankMsg::Send {
-                from_address,
-                to_address,
-                amount,
-            } => {
-                if sender != from_address {
-                    Err("Sender must equal from_address".into())
-                } else {
-                    self.send(storage, from_address, to_address, amount)
-                }
+            BankMsg::Send { to_address, amount } => self.send(storage, sender, to_address, amount),
+            m => {
+                panic!("Unsupported bank message: {:?}", m)
             }
         }
     }
@@ -168,6 +161,9 @@ impl Bank for SimpleBank {
                     .unwrap_or_else(|| coin(0, denom));
                 let res = BalanceResponse { amount };
                 Ok(to_binary(&res).map_err(|e| e.to_string())?)
+            }
+            q => {
+                panic!("Unsupported bank query: {:?}", q)
             }
         }
     }
@@ -278,7 +274,6 @@ mod test {
         // send both tokens
         let to_send = vec![coin(30, "eth"), coin(5, "btc")];
         let msg = BankMsg::Send {
-            from_address: owner.clone(),
             to_address: rcpt.clone(),
             amount: to_send.clone(),
         };
@@ -293,7 +288,6 @@ mod test {
 
         // cannot send too much
         let msg = BankMsg::Send {
-            from_address: owner.clone(),
             to_address: rcpt.clone(),
             amount: coins(20, "btc"),
         };

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -283,8 +283,8 @@ mod test {
         let poor = bank.get_balance(&store, rcpt.clone()).unwrap();
         assert_eq!(vec![coin(10, "btc"), coin(30, "eth")], poor);
 
-        // cannot send from other account
-        bank.handle(&mut store, rcpt.clone(), msg).unwrap_err();
+        // can send from any account with funds
+        bank.handle(&mut store, rcpt.clone(), msg).unwrap();
 
         // cannot send too much
         let msg = BankMsg::Send {

--- a/packages/multi-test/src/test_helpers.rs
+++ b/packages/multi-test/src/test_helpers.rs
@@ -57,7 +57,7 @@ fn init_payout(
 
 fn handle_payout(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     info: MessageInfo,
     _msg: EmptyMsg,
 ) -> Result<Response, StdError> {

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -13,6 +13,6 @@ documentation = "https://docs.cosmwasm.com"
 iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
-cosmwasm-std = { version = "0.13.2" }
+cosmwasm-std = { version = "0.14.0-alpha2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }


### PR DESCRIPTION
Closes #229 .

A couple of tests in multi-test are failing, but publishing anyway as they are interesting cases to look at (~~wrong~~ sender can now send bank messages in the multi-test context).

**Update**: This makes sense, because `BankMsg` doesn't have a `from_address` anymore. Will just modify / remove these tests.

Still needs some styling, and closely following `MIGRATING.md` guidelines, but this is compiling, passes linting AFAIK, and passes ~~almost~~ all tests.