### PR TITLE
Fix ics20 denom

### DIFF
--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -3,14 +3,15 @@ use cosmwasm_std::{
     IbcQuery, MessageInfo, Order, PortIdResponse, Response, StdResult,
 };
 
-use cw2::set_contract_version;
+use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20CoinHuman, Cw20ReceiveMsg};
 
 use crate::amount::Amount;
 use crate::error::ContractError;
 use crate::ibc::Ics20Packet;
 use crate::msg::{
-    ChannelResponse, ExecuteMsg, InitMsg, ListChannelsResponse, PortResponse, QueryMsg, TransferMsg,
+    ChannelResponse, ExecuteMsg, InitMsg, ListChannelsResponse, MigrateMsg, PortResponse, QueryMsg,
+    TransferMsg,
 };
 use crate::state::{Config, CHANNEL_INFO, CHANNEL_STATE, CONFIG};
 use cw0::{nonpayable, one_coin};
@@ -128,6 +129,17 @@ pub fn execute_transfer(
         data: None,
     };
     Ok(res)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let version = get_contract_version(deps.storage)?;
+    if version.contract != CONTRACT_NAME {
+        return Err(ContractError::CannotMigrate {
+            previous_contract: version.contract,
+        });
+    }
+    Ok(Response::default())
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/cw20-ics20/src/error.rs
+++ b/contracts/cw20-ics20/src/error.rs
@@ -37,6 +37,15 @@ pub enum ContractError {
 
     #[error("Insufficient funds to redeem voucher on channel")]
     InsufficientFunds {},
+
+    #[error("Only accepts tokens that originate on this chain, not native tokens of remote chain")]
+    NoForeignTokens {},
+
+    #[error("Parsed port from denom ({port}) doesn't match packet")]
+    FromOtherPort { port: String },
+
+    #[error("Parsed channel from denom ({channel}) doesn't match packet")]
+    FromOtherChannel { channel: String },
 }
 
 impl From<FromUtf8Error> for ContractError {

--- a/contracts/cw20-ics20/src/error.rs
+++ b/contracts/cw20-ics20/src/error.rs
@@ -46,6 +46,9 @@ pub enum ContractError {
 
     #[error("Parsed channel from denom ({channel}) doesn't match packet")]
     FromOtherChannel { channel: String },
+
+    #[error("Cannot migrate from different contract type: {previous_contract}")]
+    CannotMigrate { previous_contract: String },
 }
 
 impl From<FromUtf8Error> for ContractError {

--- a/contracts/cw20-ics20/src/msg.rs
+++ b/contracts/cw20-ics20/src/msg.rs
@@ -8,11 +8,14 @@ use cw20::Cw20ReceiveMsg;
 use crate::amount::Amount;
 use crate::state::ChannelInfo;
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct InitMsg {
     /// default timeout for ics20 packets, specified in seconds
     pub default_timeout: u64,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+pub struct MigrateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
Properly handle parsing the voucher's denom when it is returned to us.

Thanks @alpe for finding this `port/channel/orig_denom`

Also add a migrate entry point that accepts any older cw20-ics20 contract as a migration target.