### PR TITLE
Enhance multi test

### DIFF
--- a/packages/multi-test/src/test_helpers.rs
+++ b/packages/multi-test/src/test_helpers.rs
@@ -33,7 +33,8 @@ fn query_error(_deps: Deps, _env: Env, _msg: EmptyMsg) -> Result<Binary, StdErro
 }
 
 pub fn contract_error() -> Box<dyn Contract> {
-    let contract = ContractWrapper::new(handle_error, init_error, query_error);
+    let contract: ContractWrapper<_, _, _, _, _, _, _, String, String> =
+        ContractWrapper::new(handle_error, init_error, query_error);
     Box::new(contract)
 }
 


### PR DESCRIPTION
Make this compatible with more advanced workflows

- [x] Support returning Response<C> with custom message (this was a TODO)
- [x] Add support for contract wrappers with `sudo` entrypoint

TODO (other PR?)
- [ ] Expose `sudo` on top level
- [ ] Add support for `reply` entry point
- [ ] Process `submessages` in app and pass response into `reply`