### PR TITLE
Implement PrimaryKey for &Addr by removing unused parse_key

### DIFF
--- a/contracts/cw3-fixed-multisig/src/state.rs
+++ b/contracts/cw3-fixed-multisig/src/state.rs
@@ -2,11 +2,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
-use cosmwasm_std::{BlockInfo, CosmosMsg, Empty, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, BlockInfo, CosmosMsg, Empty, StdError, StdResult, Storage};
 
 use cw0::{Duration, Expiration};
 use cw3::{Status, Vote};
-use cw_storage_plus::{AddrRef, Item, Map, U64Key};
+use cw_storage_plus::{Item, Map, U64Key};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Config {
@@ -57,9 +57,9 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");
 
 // multiple-item maps
-pub const VOTERS: Map<AddrRef, u64> = Map::new("voters");
+pub const VOTERS: Map<&Addr, u64> = Map::new("voters");
 pub const PROPOSALS: Map<U64Key, Proposal> = Map::new("proposals");
-pub const BALLOTS: Map<(U64Key, AddrRef), Ballot> = Map::new("ballots");
+pub const BALLOTS: Map<(U64Key, &Addr), Ballot> = Map::new("ballots");
 
 pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;

--- a/packages/storage-plus/src/helpers.rs
+++ b/packages/storage-plus/src/helpers.rs
@@ -84,12 +84,6 @@ pub(crate) fn encode_length(namespace: &[u8]) -> [u8; 2] {
     [length_bytes[2], length_bytes[3]]
 }
 
-// pub(crate) fn decode_length(prefix: [u8; 2]) -> usize {
-pub(crate) fn decode_length(prefix: &[u8]) -> usize {
-    // TODO: enforce exactly 2 bytes somehow, but usable with slices
-    (prefix[0] as usize) * 256 + (prefix[1] as usize)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -1,3 +1,4 @@
+use cosmwasm_std::Addr;
 use std::marker::PhantomData;
 
 use crate::addr::AddrRef;
@@ -134,6 +135,17 @@ impl<'a> PrimaryKey<'a> for PkOwned {
 impl<'a> Prefixer<'a> for PkOwned {
     fn prefix(&self) -> Vec<&[u8]> {
         vec![&self.0]
+    }
+}
+
+/// type safe version to ensure address was validated before use.
+impl<'a> PrimaryKey<'a> for &'a Addr {
+    type Prefix = ();
+    type SubPrefix = ();
+
+    fn key(&self) -> Vec<&[u8]> {
+        // this is simple, we don't add more prefixes
+        vec![self.as_ref().as_bytes()]
     }
 }
 


### PR DESCRIPTION
The trait `PrimaryKey` puts a lot of requirements on the type implementing it. It requires zero-copy serialization and zero-copy deserialization.

However, deserializing the bytes into the key type is never used. If we remove it, we can easily implemement PrimaryKey for &Addr.

------

Do not merge as is. Target branch is a copy of the fork from https://github.com/CosmWasm/cosmwasm-plus/pull/260.