### PR TITLE
Take storake keys as reference (K -> &K)

### DIFF
--- a/contracts/cw3-fixed-multisig/src/state.rs
+++ b/contracts/cw3-fixed-multisig/src/state.rs
@@ -2,11 +2,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
-use cosmwasm_std::{BlockInfo, CosmosMsg, Empty, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, BlockInfo, CosmosMsg, Empty, StdError, StdResult, Storage};
 
 use cw0::{Duration, Expiration};
 use cw3::{Status, Vote};
-use cw_storage_plus::{AddrRef, Item, Map, U64Key};
+use cw_storage_plus::{Item, Map, U64Key};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Config {
@@ -57,9 +57,9 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");
 
 // multiple-item maps
-pub const VOTERS: Map<AddrRef, u64> = Map::new("voters");
+pub const VOTERS: Map<Addr, u64> = Map::new("voters");
 pub const PROPOSALS: Map<U64Key, Proposal> = Map::new("proposals");
-pub const BALLOTS: Map<(U64Key, AddrRef), Ballot> = Map::new("ballots");
+pub const BALLOTS: Map<(U64Key, Addr), Ballot> = Map::new("ballots");
 
 pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -105,12 +105,12 @@ where
 {
     fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()> {
         let idx = (self.index)(data, pk.to_vec());
-        self.idx_map.save(store, idx, &(pk.len() as u32))
+        self.idx_map.save(store, &idx, &(pk.len() as u32))
     }
 
     fn remove(&self, store: &mut dyn Storage, pk: &[u8], old_data: &T) -> StdResult<()> {
         let idx = (self.index)(old_data, pk.to_vec());
-        self.idx_map.remove(store, idx);
+        self.idx_map.remove(store, &idx);
         Ok(())
     }
 }
@@ -240,7 +240,7 @@ where
         let idx = (self.index)(data);
         // error if this is already set
         self.idx_map
-            .update(store, idx, |existing| -> StdResult<_> {
+            .update(store, &idx, |existing| -> StdResult<_> {
                 match existing {
                     Some(_) => Err(StdError::generic_err("Violates unique constraint on index")),
                     None => Ok(UniqueRef::<T> {
@@ -254,7 +254,7 @@ where
 
     fn remove(&self, store: &mut dyn Storage, _pk: &[u8], old_data: &T) -> StdResult<()> {
         let idx = (self.index)(old_data);
-        self.idx_map.remove(store, idx);
+        self.idx_map.remove(store, &idx);
         Ok(())
     }
 }
@@ -283,7 +283,7 @@ where
     }
 
     /// returns all items that match this secondary index, always by pk Ascending
-    pub fn item(&self, store: &dyn Storage, idx: K) -> StdResult<Option<Pair<T>>> {
+    pub fn item(&self, store: &dyn Storage, idx: &K) -> StdResult<Option<Pair<T>>> {
         let data = self
             .idx_map
             .may_load(store, idx)?


### PR DESCRIPTION
This change encourages the use of ownes types as `PrimaryKey`, which makes it very easy to deserialize bytes into owned keys. This can be implemented for `Addr`.

Since you cannot deserialize borrowed bytes into an owned object, a copy is created in `parse_key`. However, `parse_key` is never used.

In order to avoid copying around owned keys when thes are needed in multiple locations, the key arguments of all the storage functions were turned into references.

This is basically how the type system of standard library maps like https://doc.rust-lang.org/std/collections/struct.HashMap.html works: You have an owned key type `K` that is used plain in a few places. But [get](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.get) takes a reference. In `HashMap` the `K` can be of unknown size (e.g. `[u8]`). This is something we cannot do as long as we want to keep `parse_key`, which deserializes into an owned `K`.

--------

Do not merge as is. Target branch is a copy of the fork from #260.