### PR TITLE
Remove unused PrimaryKey::parse_key

### DIFF
--- a/packages/storage-plus/src/helpers.rs
+++ b/packages/storage-plus/src/helpers.rs
@@ -84,12 +84,6 @@ pub(crate) fn encode_length(namespace: &[u8]) -> [u8; 2] {
     [length_bytes[2], length_bytes[3]]
 }
 
-// pub(crate) fn decode_length(prefix: [u8; 2]) -> usize {
-pub(crate) fn decode_length(prefix: &[u8]) -> usize {
-    // TODO: enforce exactly 2 bytes somehow, but usable with slices
-    (prefix[0] as usize) * 256 + (prefix[1] as usize)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
-use std::str::from_utf8;
 
-use crate::helpers::{decode_length, namespaces_with_key};
+use crate::helpers::namespaces_with_key;
 use crate::Endian;
 
 // pub trait PrimaryKey<'a>: Copy {
@@ -17,10 +16,6 @@ pub trait PrimaryKey<'a>: Clone {
         let l = keys.len();
         namespaces_with_key(&keys[0..l - 1], &keys[l - 1])
     }
-
-    /// extracts a single or composite key from a joined key,
-    /// only lives as long as the original bytes
-    fn parse_key(serialized: &'a [u8]) -> Self;
 }
 
 impl<'a> PrimaryKey<'a> for &'a [u8] {
@@ -30,10 +25,6 @@ impl<'a> PrimaryKey<'a> for &'a [u8] {
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
         vec![self]
-    }
-
-    fn parse_key(serialized: &'a [u8]) -> Self {
-        serialized
     }
 }
 
@@ -46,10 +37,6 @@ impl<'a> PrimaryKey<'a> for &'a str {
         // this is simple, we don't add more prefixes
         vec![self.as_bytes()]
     }
-
-    fn parse_key(serialized: &'a [u8]) -> Self {
-        from_utf8(serialized).unwrap()
-    }
 }
 
 // use generics for combining there - so we can use &[u8], PkOwned, or IntKey
@@ -61,13 +48,6 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for
         let mut keys = self.0.key();
         keys.extend(&self.1.key());
         keys
-    }
-
-    fn parse_key(serialized: &'a [u8]) -> Self {
-        let l = decode_length(&serialized[0..2]);
-        let first = &serialized[2..l + 2];
-        let second = &serialized[l + 2..];
-        (T::parse_key(first), U::parse_key(second))
     }
 }
 
@@ -83,19 +63,6 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a> + Prefixer<'a>, V: 
         keys.extend(&self.1.key());
         keys.extend(&self.2.key());
         keys
-    }
-
-    fn parse_key(serialized: &'a [u8]) -> Self {
-        let l1 = decode_length(&serialized[0..2]);
-        let first = &serialized[2..2 + l1];
-        let l2 = decode_length(&serialized[2 + l1..2 + l1 + 2]);
-        let second = &serialized[2 + l1 + 2..2 + l1 + 2 + l2];
-        let third = &serialized[2 + l1 + 2 + l2..];
-        (
-            T::parse_key(first),
-            U::parse_key(second),
-            V::parse_key(third),
-        )
     }
 }
 
@@ -161,10 +128,6 @@ impl<'a> PrimaryKey<'a> for PkOwned {
     fn key(&self) -> Vec<&[u8]> {
         vec![&self.0]
     }
-
-    fn parse_key(serialized: &'a [u8]) -> Self {
-        PkOwned(serialized.to_vec())
-    }
 }
 
 impl<'a> Prefixer<'a> for PkOwned {
@@ -180,10 +143,6 @@ impl<'a, T: AsRef<PkOwned> + From<PkOwned> + Clone> PrimaryKey<'a> for T {
 
     fn key(&self) -> Vec<&[u8]> {
         self.as_ref().key()
-    }
-
-    fn parse_key(serialized: &'a [u8]) -> Self {
-        PkOwned::parse_key(serialized).into()
     }
 }
 
@@ -291,8 +250,7 @@ mod test {
         assert_eq!("hello".as_bytes(), path[0]);
 
         let joined = k.joined_key();
-        let parsed = K::parse_key(&joined);
-        assert_eq!(parsed, "hello");
+        assert_eq!(joined, b"hello")
     }
 
     #[test]
@@ -341,71 +299,6 @@ mod test {
         let dir = k.0.prefix();
         assert_eq!(2, dir.len());
         assert_eq!(dir, vec![foo, b"bar"]);
-    }
-
-    #[test]
-    fn parse_joined_keys_pk1() {
-        type K<'a> = &'a [u8];
-
-        let key: K = b"four";
-        let joined = key.joined_key();
-        assert_eq!(key, joined.as_slice());
-        let parsed = K::parse_key(&joined);
-        assert_eq!(key, parsed);
-    }
-
-    #[test]
-    fn parse_joined_keys_pk2() {
-        type K<'a> = (&'a [u8], &'a [u8]);
-
-        let key: K = (b"four", b"square");
-        let joined = key.joined_key();
-        assert_eq!(4 + 6 + 2, joined.len());
-        let parsed = K::parse_key(&joined);
-        assert_eq!(key, parsed);
-    }
-
-    #[test]
-    fn parse_joined_keys_pk3() {
-        type K<'a> = (&'a str, U32Key, &'a [u8]);
-
-        let key: K = ("four", 15.into(), b"cinco");
-        let joined = key.joined_key();
-        assert_eq!(4 + 4 + 5 + 2 * 2, joined.len());
-        let parsed = K::parse_key(&joined);
-        assert_eq!(key, parsed);
-    }
-
-    #[test]
-    fn parse_joined_keys_pk3_alt() {
-        type K<'a> = (&'a str, U64Key, &'a str);
-
-        let key: K = ("one", 222.into(), "three");
-        let joined = key.joined_key();
-        assert_eq!(3 + 8 + 5 + 2 * 2, joined.len());
-        let parsed = K::parse_key(&joined);
-        assert_eq!(key, parsed);
-    }
-
-    #[test]
-    fn parse_joined_keys_int() {
-        let key: U64Key = 12345678.into();
-        let joined = key.joined_key();
-        assert_eq!(8, joined.len());
-        let parsed = U64Key::parse_key(&joined);
-        assert_eq!(key, parsed);
-    }
-
-    #[test]
-    fn parse_joined_keys_string_int() {
-        type K<'a> = (U32Key, &'a str);
-
-        let key: K = (54321.into(), "random");
-        let joined = key.joined_key();
-        assert_eq!(2 + 4 + 6, joined.len());
-        let parsed = K::parse_key(&joined);
-        assert_eq!(key, parsed);
-        assert_eq!("random", parsed.1);
     }
 
     #[test]


### PR DESCRIPTION
This is the first commit of https://github.com/CosmWasm/cosmwasm-plus/pull/264.

It unlocks but does not include implementing `PrimaryKey<'a> for &'a Addr`