### PR TITLE
Cw4 group list members by weight

### DIFF
--- a/contracts/cw4-group/schema/query_msg.json
+++ b/contracts/cw4-group/schema/query_msg.json
@@ -58,6 +58,47 @@
       "additionalProperties": false
     },
     {
+      "description": "Returns MembersListResponse, sorted by weight descending",
+      "type": "object",
+      "required": [
+        "list_members_by_weight"
+      ],
+      "properties": {
+        "list_members_by_weight": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Returns MemberResponse",
       "type": "object",
       "required": [

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -176,7 +176,7 @@ fn query_total_weight(deps: Deps) -> StdResult<TotalWeightResponse> {
 fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<MemberResponse> {
     let addr = deps.api.addr_validate(&addr)?;
     let weight = match height {
-        Some(h) => members().primary.may_load_at_height(deps.storage, &addr, h),
+        Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
     }?;
     Ok(MemberResponse { weight })

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -222,7 +222,7 @@ fn list_members_by_weight(
     let members: StdResult<Vec<_>> = members()
         .idx
         .weight
-        .range(deps.storage, start, None, Order::Descending)
+        .range(deps.storage, None, start, Order::Descending)
         .take(limit)
         .map(|item| {
             let (key, weight) = item?;

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -308,9 +308,10 @@ mod tests {
         let members = list_members(deps.as_ref(), None, None).unwrap();
         assert_eq!(members.members.len(), 2);
         // TODO: assert the set is proper
-
-        // TODO: Test pagination / limits
     }
+
+    // TODO: Test member_by_weight
+    // Test pagination / limits
 
     fn assert_users<S: Storage, A: Api, Q: Querier>(
         deps: &OwnedDeps<S, A, Q>,

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -232,7 +232,6 @@ fn list_members_by_weight(
     let members: StdResult<Vec<_>> = members()
         .idx
         .weight
-        .sub_prefix(()) // FIXME: Use range() directly, and impl EmptyPrefix for IntKey<T>?
         .range(deps.storage, start, None, Order::Descending)
         .take(limit)
         .map(|item| {

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -14,6 +14,7 @@ use cw_storage_plus::Bound;
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::{members, ADMIN, HOOKS, TOTAL};
+use std::mem::size_of;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw4-group";
@@ -221,7 +222,7 @@ fn list_members_by_weight(
         Bound::exclusive(
             [
                 b"\x00".as_ref(),
-                b"\x08".as_ref(),
+                &[size_of::<u64>() as u8],
                 &w.to_be_bytes(),
                 a.as_bytes(),
             ]

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -13,7 +13,7 @@ use cw_storage_plus::Bound;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{members, ADMIN, HOOKS, MEMBERS, TOTAL};
+use crate::state::{members, ADMIN, HOOKS, TOTAL};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw4-group";
@@ -176,7 +176,7 @@ fn query_total_weight(deps: Deps) -> StdResult<TotalWeightResponse> {
 fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<MemberResponse> {
     let addr = deps.api.addr_validate(&addr)?;
     let weight = match height {
-        Some(h) => MEMBERS.may_load_at_height(deps.storage, &addr, h),
+        Some(h) => members().primary.may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
     }?;
     Ok(MemberResponse { weight })
@@ -195,7 +195,7 @@ fn list_members(
     let addr = maybe_addr(deps.api, start_after)?;
     let start = addr.map(|addr| Bound::exclusive(addr.to_string()));
 
-    let members: StdResult<Vec<_>> = MEMBERS
+    let members: StdResult<Vec<_>> = members()
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {

--- a/contracts/cw4-group/src/msg.rs
+++ b/contracts/cw4-group/src/msg.rs
@@ -41,6 +41,11 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    /// Returns MembersListResponse, sorted by weight descending
+    ListMembersByWeight {
+        start_after: Option<(u64, String)>,
+        limit: Option<u32>,
+    },
     /// Returns MemberResponse
     Member {
         addr: String,

--- a/contracts/cw4-group/src/state.rs
+++ b/contracts/cw4-group/src/state.rs
@@ -2,20 +2,13 @@ use cosmwasm_std::Addr;
 use cw4::TOTAL_KEY;
 use cw_controllers::{Admin, Hooks};
 use cw_storage_plus::{
-    Index, IndexList, IndexedSnapshotMap, Item, MultiIndex, PkOwned, SnapshotMap, Strategy, U64Key,
+    Index, IndexList, IndexedSnapshotMap, Item, MultiIndex, PkOwned, Strategy, U64Key,
 };
 
 pub const ADMIN: Admin = Admin::new("admin");
 pub const HOOKS: Hooks = Hooks::new("cw4-hooks");
 
 pub const TOTAL: Item<u64> = Item::new(TOTAL_KEY);
-
-pub const MEMBERS: SnapshotMap<&Addr, u64> = SnapshotMap::new(
-    cw4::MEMBERS_KEY,
-    cw4::MEMBERS_CHECKPOINTS,
-    cw4::MEMBERS_CHANGELOG,
-    Strategy::EveryBlock,
-);
 
 pub struct MemberIndexes<'a> {
     // pk goes to second tuple element

--- a/contracts/cw4-group/src/state.rs
+++ b/contracts/cw4-group/src/state.rs
@@ -1,7 +1,9 @@
 use cosmwasm_std::Addr;
 use cw4::TOTAL_KEY;
 use cw_controllers::{Admin, Hooks};
-use cw_storage_plus::{Item, SnapshotMap, Strategy};
+use cw_storage_plus::{
+    Index, IndexList, IndexedSnapshotMap, Item, MultiIndex, PkOwned, SnapshotMap, Strategy, U64Key,
+};
 
 pub const ADMIN: Admin = Admin::new("admin");
 pub const HOOKS: Hooks = Hooks::new("cw4-hooks");
@@ -14,3 +16,32 @@ pub const MEMBERS: SnapshotMap<&Addr, u64> = SnapshotMap::new(
     cw4::MEMBERS_CHANGELOG,
     Strategy::EveryBlock,
 );
+
+pub struct MemberIndexes<'a> {
+    // pk goes to second tuple element
+    pub weight: MultiIndex<'a, (U64Key, PkOwned), u64>,
+}
+
+impl<'a> IndexList<u64> for MemberIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<u64>> + '_> {
+        let v: Vec<&dyn Index<u64>> = vec![&self.weight];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, u64, MemberIndexes<'a>> {
+    let indexes = MemberIndexes {
+        weight: MultiIndex::new(
+            |&w, k| (U64Key::new(w), PkOwned(k)),
+            cw4::MEMBERS_KEY,
+            "members__weight",
+        ),
+    };
+    IndexedSnapshotMap::new(
+        cw4::MEMBERS_KEY,
+        cw4::MEMBERS_CHECKPOINTS,
+        cw4::MEMBERS_CHANGELOG,
+        Strategy::EveryBlock,
+        indexes,
+    )
+}


### PR DESCRIPTION
Uses `IndexedSnapshotMap` to do the `list_members` query sorted by weight.

Continuation of #255. Uses #271.