### PR TITLE
Cw4 stake list members by weight

### DIFF
--- a/contracts/cw4-stake/schema/query_msg.json
+++ b/contracts/cw4-stake/schema/query_msg.json
@@ -99,6 +99,47 @@
       "additionalProperties": false
     },
     {
+      "description": "Returns MembersListResponse, sorted by weight descending.",
+      "type": "object",
+      "required": [
+        "list_members_by_weight"
+      ],
+      "properties": {
+        "list_members_by_weight": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Returns MemberResponse",
       "type": "object",
       "required": [

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -323,7 +323,7 @@ pub fn query_staked(deps: Deps, addr: String) -> StdResult<StakedResponse> {
 fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<MemberResponse> {
     let addr = deps.api.addr_validate(&addr)?;
     let weight = match height {
-        Some(h) => members().primary.may_load_at_height(deps.storage, &addr, h),
+        Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
     }?;
     Ok(MemberResponse { weight })

--- a/contracts/cw4-stake/src/msg.rs
+++ b/contracts/cw4-stake/src/msg.rs
@@ -60,6 +60,11 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    /// Returns MembersListResponse, sorted by weight descending.
+    ListMembersByWeight {
+        start_after: Option<(u64, String)>,
+        limit: Option<u32>,
+    },
     /// Returns MemberResponse
     Member {
         addr: String,

--- a/contracts/cw4-stake/src/state.rs
+++ b/contracts/cw4-stake/src/state.rs
@@ -6,7 +6,10 @@ use cw0::Duration;
 use cw20::Denom;
 use cw4::TOTAL_KEY;
 use cw_controllers::{Admin, Claims, Hooks};
-use cw_storage_plus::{Item, Map, SnapshotMap, Strategy};
+use cw_storage_plus::{
+    Index, IndexList, IndexedSnapshotMap, Item, Map, MultiIndex, PkOwned, SnapshotMap, Strategy,
+    U64Key,
+};
 
 pub const CLAIMS: Claims = Claims::new("claims");
 
@@ -30,5 +33,34 @@ pub const MEMBERS: SnapshotMap<&Addr, u64> = SnapshotMap::new(
     cw4::MEMBERS_CHANGELOG,
     Strategy::EveryBlock,
 );
+
+pub struct MemberIndexes<'a> {
+    // pk goes to second tuple element
+    pub weight: MultiIndex<'a, (U64Key, PkOwned), u64>,
+}
+
+impl<'a> IndexList<u64> for MemberIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<u64>> + '_> {
+        let v: Vec<&dyn Index<u64>> = vec![&self.weight];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, u64, MemberIndexes<'a>> {
+    let indexes = MemberIndexes {
+        weight: MultiIndex::new(
+            |&w, k| (U64Key::new(w), PkOwned(k)),
+            cw4::MEMBERS_KEY,
+            "members__weight",
+        ),
+    };
+    IndexedSnapshotMap::new(
+        cw4::MEMBERS_KEY,
+        cw4::MEMBERS_CHECKPOINTS,
+        cw4::MEMBERS_CHANGELOG,
+        Strategy::EveryBlock,
+        indexes,
+    )
+}
 
 pub const STAKE: Map<&Addr, Uint128> = Map::new("stake");


### PR DESCRIPTION
Similar to #272 but for `cw4-stake`.

I think we should consider moving / adding this functionality to the `cw4` spec, and implement `list_members_by_weight` under `Cw4Contract`, to avoid repetition, and ease maintenance / use.