### PR TITLE
Better error message with missing sudo (no parse error)

### DIFF
--- a/packages/multi-test/src/test_helpers.rs
+++ b/packages/multi-test/src/test_helpers.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 };
 use cw_storage_plus::Item;
 
-use crate::wasm::{Contract, ContractWrapper};
+use crate::wasm::{Any, Contract, ContractWrapper};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct EmptyMsg {}
@@ -37,7 +37,7 @@ fn query_error(_deps: Deps, _env: Env, _msg: EmptyMsg) -> Result<Binary, StdErro
 }
 
 pub fn contract_error() -> Box<dyn Contract<Empty>> {
-    let contract: ContractWrapper<_, _, _, _, _, _, _, String, String> =
+    let contract: ContractWrapper<_, _, _, _, _, _, _, Any, Any> =
         ContractWrapper::new(handle_error, init_error, query_error);
     Box::new(contract)
 }
@@ -47,7 +47,7 @@ pub fn contract_error_custom<C>() -> Box<dyn Contract<C>>
 where
     C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
 {
-    let contract: ContractWrapper<_, _, _, _, _, _, _, String, String> =
+    let contract: ContractWrapper<_, _, _, _, _, _, _, Any, Any> =
         ContractWrapper::new_with_empty(handle_error, init_error, query_error);
     Box::new(contract)
 }

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref;
@@ -10,6 +10,18 @@ use cosmwasm_std::{
 };
 
 use crate::transactions::{RepLog, StorageTransaction};
+use std::fmt::Formatter;
+
+/// This is used as a placeholder type that can be anything
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Any {}
+
+// We couldn't use Empty as it didn't implement Display. Shall we upstream this?
+impl fmt::Display for Any {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("{Any}")
+    }
+}
 
 /// Interface to call into a Contract
 pub trait Contract<T>
@@ -48,7 +60,7 @@ type QueryClosure<T, E> = Box<dyn Fn(Deps, Env, T) -> Result<Binary, E>>;
 
 /// Wraps the exported functions from a contract and provides the normalized format
 /// Place T4 and E4 at the end, as we just want default placeholders for most contracts that don't have sudo
-pub struct ContractWrapper<T1, T2, T3, E1, E2, E3, C = Empty, T4 = String, E4 = String>
+pub struct ContractWrapper<T1, T2, T3, E1, E2, E3, C = Empty, T4 = Any, E4 = Any>
 where
     T1: DeserializeOwned,
     T2: DeserializeOwned,


### PR DESCRIPTION
Closes #278 

I introduced `Any` rather than `String`. `Any` is like `Empty` (parses any struct), but it has a needed `Display` implementation.
When we are happy with this, and merged, we can port over the `Display` implementation to `cosmwasm_std::Empty` for the future.