### PR TITLE
Pkowned to vec u8

### DIFF
--- a/contracts/cw721-base/src/contract.rs
+++ b/contracts/cw721-base/src/contract.rs
@@ -17,7 +17,7 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, MintMsg, MinterResponse, QueryMsg};
 use crate::state::{
     increment_tokens, num_tokens, tokens, Approval, TokenInfo, CONTRACT_INFO, MINTER, OPERATORS,
 };
-use cw_storage_plus::{Bound, PkOwned};
+use cw_storage_plus::Bound;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw721-base";
@@ -516,7 +516,7 @@ fn query_tokens(
         .owner
         .pks(
             deps.storage,
-            PkOwned(Vec::from(owner_addr.as_ref())),
+            Vec::from(owner_addr.as_ref()),
             start,
             None,
             Order::Ascending,

--- a/contracts/cw721-base/src/state.rs
+++ b/contracts/cw721-base/src/state.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, BlockInfo, StdResult, Storage};
 use cw721::{ContractInfoResponse, Expiration};
-use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex, PkOwned};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TokenInfo {
@@ -53,7 +53,7 @@ pub fn increment_tokens(storage: &mut dyn Storage) -> StdResult<u64> {
 
 pub struct TokenIndexes<'a> {
     // pk goes to second tuple element
-    pub owner: MultiIndex<'a, (PkOwned, PkOwned), TokenInfo>,
+    pub owner: MultiIndex<'a, (Vec<u8>, Vec<u8>), TokenInfo>,
 }
 
 impl<'a> IndexList<TokenInfo> for TokenIndexes<'a> {
@@ -66,7 +66,7 @@ impl<'a> IndexList<TokenInfo> for TokenIndexes<'a> {
 pub fn tokens<'a>() -> IndexedMap<'a, &'a str, TokenInfo, TokenIndexes<'a>> {
     let indexes = TokenIndexes {
         owner: MultiIndex::new(
-            |d, k| (PkOwned(Vec::from(d.owner.as_ref())), PkOwned(k)),
+            |d, k| (Vec::from(d.owner.as_ref()), k),
             "tokens",
             "tokens__owner",
         ),

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -9,21 +9,21 @@ use cosmwasm_std::{from_slice, Binary, Order, Pair, StdError, StdResult, Storage
 use crate::helpers::namespaces_with_key;
 use crate::keys::EmptyPrefix;
 use crate::map::Map;
-use crate::{Bound, PkOwned, Prefix, Prefixer, PrimaryKey, U32Key};
+use crate::{Bound, Prefix, Prefixer, PrimaryKey, U32Key};
 
-pub fn index_string(data: &str) -> PkOwned {
-    PkOwned(data.as_bytes().to_vec())
+pub fn index_string(data: &str) -> Vec<u8> {
+    data.as_bytes().to_vec()
 }
 
-pub fn index_tuple(name: &str, age: u32) -> (PkOwned, U32Key) {
+pub fn index_tuple(name: &str, age: u32) -> (Vec<u8>, U32Key) {
     (index_string(name), U32Key::new(age))
 }
 
-pub fn index_triple(name: &str, age: u32, pk: Vec<u8>) -> (PkOwned, U32Key, PkOwned) {
-    (index_string(name), U32Key::new(age), PkOwned(pk))
+pub fn index_triple(name: &str, age: u32, pk: Vec<u8>) -> (Vec<u8>, U32Key, Vec<u8>) {
+    (index_string(name), U32Key::new(age), pk)
 }
 
-pub fn index_string_tuple(data1: &str, data2: &str) -> (PkOwned, PkOwned) {
+pub fn index_string_tuple(data1: &str, data2: &str) -> (Vec<u8>, Vec<u8>) {
     (index_string(data1), index_string(data2))
 }
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -40,7 +40,7 @@ impl<'a> PrimaryKey<'a> for &'a str {
     }
 }
 
-// use generics for combining there - so we can use &[u8], PkOwned, or IntKey
+// use generics for combining there - so we can use &[u8], Vec<u8>, or IntKey
 impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for (T, U) {
     type Prefix = T;
     type SubPrefix = ();
@@ -52,7 +52,7 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for
     }
 }
 
-// use generics for combining there - so we can use &[u8], PkOwned, or IntKey
+// use generics for combining there - so we can use &[u8], Vec<u8>, or IntKey
 impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a> + Prefixer<'a>, V: PrimaryKey<'a>>
     PrimaryKey<'a> for (T, U, V)
 {
@@ -137,6 +137,21 @@ impl<'a> Prefixer<'a> for PkOwned {
     }
 }
 
+impl<'a> PrimaryKey<'a> for Vec<u8> {
+    type Prefix = ();
+    type SubPrefix = ();
+
+    fn key(&self) -> Vec<&[u8]> {
+        vec![&self]
+    }
+}
+
+impl<'a> Prefixer<'a> for Vec<u8> {
+    fn prefix(&self) -> Vec<&[u8]> {
+        vec![&self]
+    }
+}
+
 /// type safe version to ensure address was validated before use.
 impl<'a> PrimaryKey<'a> for &'a Addr {
     type Prefix = ();
@@ -154,20 +169,20 @@ impl<'a> Prefixer<'a> for &'a Addr {
     }
 }
 
-// this auto-implements PrimaryKey for all the IntKey types (and more!)
-impl<'a, T: AsRef<PkOwned> + From<PkOwned> + Clone> PrimaryKey<'a> for T {
+// this auto-implements PrimaryKey for all the IntKey types
+impl<'a, T: Endian + Clone> PrimaryKey<'a> for IntKey<T> {
     type Prefix = ();
     type SubPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
-        self.as_ref().key()
+        self.wrapped.key()
     }
 }
 
-// this auto-implements Prefixer for all the IntKey types (and more!)
-impl<'a, T: AsRef<PkOwned>> Prefixer<'a> for T {
+// this auto-implements Prefixer for all the IntKey types
+impl<'a, T: Endian> Prefixer<'a> for IntKey<T> {
     fn prefix(&self) -> Vec<&[u8]> {
-        self.as_ref().prefix()
+        self.wrapped.prefix()
     }
 }
 
@@ -191,14 +206,14 @@ pub type I128Key = IntKey<i128>;
 ///   let k: U16Key = 12345.into();
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IntKey<T: Endian> {
-    pub wrapped: PkOwned,
+    pub wrapped: Vec<u8>,
     pub data: PhantomData<T>,
 }
 
 impl<T: Endian> IntKey<T> {
     pub fn new(val: T) -> Self {
         IntKey {
-            wrapped: PkOwned(val.to_be_bytes().into()),
+            wrapped: val.to_be_bytes().into(),
             data: PhantomData,
         }
     }
@@ -210,8 +225,8 @@ impl<T: Endian> From<T> for IntKey<T> {
     }
 }
 
-impl<T: Endian> From<PkOwned> for IntKey<T> {
-    fn from(wrap: PkOwned) -> Self {
+impl<T: Endian> From<Vec<u8>> for IntKey<T> {
+    fn from(wrap: Vec<u8>) -> Self {
         // TODO: assert proper length
         IntKey {
             wrapped: wrap,
@@ -220,21 +235,9 @@ impl<T: Endian> From<PkOwned> for IntKey<T> {
     }
 }
 
-impl<T: Endian> From<Vec<u8>> for IntKey<T> {
-    fn from(wrap: Vec<u8>) -> Self {
-        PkOwned(wrap).into()
-    }
-}
-
 impl<T: Endian> From<IntKey<T>> for Vec<u8> {
     fn from(k: IntKey<T>) -> Vec<u8> {
-        k.wrapped.0
-    }
-}
-
-impl<T: Endian> AsRef<PkOwned> for IntKey<T> {
-    fn as_ref(&self) -> &PkOwned {
-        &self.wrapped
+        k.wrapped
     }
 }
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -118,25 +118,6 @@ impl EmptyPrefix for () {
     fn new() {}
 }
 
-// Add support for an dynamic keys - constructor functions below
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PkOwned(pub Vec<u8>);
-
-impl<'a> PrimaryKey<'a> for PkOwned {
-    type Prefix = ();
-    type SubPrefix = ();
-
-    fn key(&self) -> Vec<&[u8]> {
-        vec![&self.0]
-    }
-}
-
-impl<'a> Prefixer<'a> for PkOwned {
-    fn prefix(&self) -> Vec<&[u8]> {
-        vec![&self.0]
-    }
-}
-
 impl<'a> PrimaryKey<'a> for Vec<u8> {
     type Prefix = ();
     type SubPrefix = ();
@@ -198,7 +179,7 @@ pub type I32Key = IntKey<i32>;
 pub type I64Key = IntKey<i64>;
 pub type I128Key = IntKey<i128>;
 
-/// It will cast one-particular int type into a Key via PkOwned, ensuring you don't mix up u32 and u64
+/// It will cast one-particular int type into a Key via Vec<u8>, ensuring you don't mix up u32 and u64
 /// You can use new or the from/into pair to build a key from an int:
 ///
 ///   let k = U64Key::new(12345);

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -22,7 +22,7 @@ pub use indexes::{
 };
 pub use item::Item;
 pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
-pub use keys::{PkOwned, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
+pub use keys::{Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]


### PR DESCRIPTION
Closes #199.

After some restructuring of the `PrimaryKey` and `Prefixer` trait impls, it was straightforward to replace `PkOwned` by `Vec<u8>`, and remove `PkOwned` entirely.