### PR TITLE
Expose contract components

### DIFF
--- a/contracts/cw1-subkeys/src/lib.rs
+++ b/contracts/cw1-subkeys/src/lib.rs
@@ -2,3 +2,5 @@ pub mod contract;
 mod error;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw1155-base/examples/schema.rs
+++ b/contracts/cw1155-base/examples/schema.rs
@@ -3,22 +3,28 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
+use cw1155::{
+    ApprovedForAllResponse, BalanceResponse, BatchBalanceResponse, Cw1155BatchReceiveMsg,
+    Cw1155ExecuteMsg, Cw1155QueryMsg, Cw1155ReceiveMsg, IsApprovedForAllResponse,
+    TokenInfoResponse, TokensResponse,
+};
+use cw1155_base::msg::InstantiateMsg;
+
 fn main() {
     let mut out_dir = current_dir().unwrap();
     out_dir.push("schema");
     create_dir_all(&out_dir).unwrap();
     remove_schemas(&out_dir).unwrap();
 
-    export_schema(&schema_for!(cw1155_base::InstantiateMsg), &out_dir);
-
-    export_schema(&schema_for!(cw1155::Cw1155ExecuteMsg), &out_dir);
-    export_schema(&schema_for!(cw1155::Cw1155QueryMsg), &out_dir);
-    export_schema(&schema_for!(cw1155::Cw1155ReceiveMsg), &out_dir);
-    export_schema(&schema_for!(cw1155::Cw1155BatchReceiveMsg), &out_dir);
-    export_schema(&schema_for!(cw1155::BalanceResponse), &out_dir);
-    export_schema(&schema_for!(cw1155::BatchBalanceResponse), &out_dir);
-    export_schema(&schema_for!(cw1155::ApprovedForAllResponse), &out_dir);
-    export_schema(&schema_for!(cw1155::IsApprovedForAllResponse), &out_dir);
-    export_schema(&schema_for!(cw1155::TokenInfoResponse), &out_dir);
-    export_schema(&schema_for!(cw1155::TokensResponse), &out_dir);
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(Cw1155ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(Cw1155QueryMsg), &out_dir);
+    export_schema(&schema_for!(Cw1155ReceiveMsg), &out_dir);
+    export_schema(&schema_for!(Cw1155BatchReceiveMsg), &out_dir);
+    export_schema(&schema_for!(BalanceResponse), &out_dir);
+    export_schema(&schema_for!(BatchBalanceResponse), &out_dir);
+    export_schema(&schema_for!(ApprovedForAllResponse), &out_dir);
+    export_schema(&schema_for!(IsApprovedForAllResponse), &out_dir);
+    export_schema(&schema_for!(TokenInfoResponse), &out_dir);
+    export_schema(&schema_for!(TokensResponse), &out_dir);
 }

--- a/contracts/cw1155-base/src/lib.rs
+++ b/contracts/cw1155-base/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod contract;
 mod error;
-mod msg;
-mod state;
+pub mod msg;
+pub mod state;
 
-pub use msg::InstantiateMsg;
+pub use crate::error::ContractError;

--- a/contracts/cw20-atomic-swap/src/lib.rs
+++ b/contracts/cw20-atomic-swap/src/lib.rs
@@ -2,3 +2,5 @@ pub mod contract;
 mod error;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw20-bonding/src/lib.rs
+++ b/contracts/cw20-bonding/src/lib.rs
@@ -3,3 +3,5 @@ pub mod curves;
 mod error;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw20-escrow/src/lib.rs
+++ b/contracts/cw20-escrow/src/lib.rs
@@ -3,3 +3,5 @@ mod error;
 mod integration_test;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw20-ics20/src/lib.rs
+++ b/contracts/cw20-ics20/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod amount;
 pub mod contract;
-pub mod error;
+mod error;
 pub mod ibc;
 pub mod msg;
 pub mod state;
 mod test_helpers;
+
+pub use crate::error::ContractError;

--- a/contracts/cw20-staking/src/lib.rs
+++ b/contracts/cw20-staking/src/lib.rs
@@ -2,3 +2,5 @@ pub mod contract;
 mod error;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw3-fixed-multisig/src/lib.rs
+++ b/contracts/cw3-fixed-multisig/src/lib.rs
@@ -3,3 +3,5 @@ mod error;
 mod integration_tests;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw3-flex-multisig/src/lib.rs
+++ b/contracts/cw3-flex-multisig/src/lib.rs
@@ -2,3 +2,5 @@ pub mod contract;
 mod error;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw4-group/src/lib.rs
+++ b/contracts/cw4-group/src/lib.rs
@@ -3,3 +3,5 @@ pub mod error;
 pub mod helpers;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw4-stake/src/lib.rs
+++ b/contracts/cw4-stake/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod contract;
-pub mod error;
+mod error;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -2,3 +2,5 @@ pub mod contract;
 mod error;
 pub mod msg;
 pub mod state;
+
+pub use crate::error::ContractError;


### PR DESCRIPTION
When importing/extending contracts, access to base contract's errors, msgs required. This PR will allow that.