### PR TITLE
Support submessages in multitest

### DIFF
--- a/contracts/cw20-escrow/src/integration_test.rs
+++ b/contracts/cw20-escrow/src/integration_test.rs
@@ -97,8 +97,14 @@ fn escrow_happy_path_cw20_tokens() {
     let res = router
         .execute_contract(owner.clone(), cash_addr.clone(), &send_msg, &[])
         .unwrap();
-    println!("{:?}", res.attributes);
-    assert_eq!(6, res.attributes.len());
+    assert_eq!(2, res.events.len());
+    println!("{:?}", res.events);
+    let cw20_attr = res.custom_attrs(0);
+    println!("{:?}", cw20_attr);
+    assert_eq!(4, cw20_attr.len());
+    let escrow_attr = res.custom_attrs(1);
+    println!("{:?}", escrow_attr);
+    assert_eq!(2, escrow_attr.len());
 
     // ensure balances updated
     let owner_balance = cash.balance(&router, owner.clone()).unwrap();

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -751,8 +751,8 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER3), flex_addr.clone(), &proposal, &[])
             .unwrap();
         assert_eq!(
-            res.attributes,
-            vec![
+            res.custom_attrs(0),
+            &[
                 attr("action", "propose"),
                 attr("sender", VOTER3),
                 attr("proposal_id", 1),
@@ -765,8 +765,8 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER4), flex_addr, &proposal, &[])
             .unwrap();
         assert_eq!(
-            res.attributes,
-            vec![
+            res.custom_attrs(0),
+            &[
                 attr("action", "propose"),
                 attr("sender", VOTER4),
                 attr("proposal_id", 2),
@@ -832,7 +832,7 @@ mod tests {
         let res = app
             .execute_contract(Addr::unchecked(VOTER1), flex_addr.clone(), &proposal, &[])
             .unwrap();
-        let proposal_id1: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id1: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // another proposal immediately passes
         app.update_block(next_block);
@@ -840,7 +840,7 @@ mod tests {
         let res = app
             .execute_contract(Addr::unchecked(VOTER3), flex_addr.clone(), &proposal, &[])
             .unwrap();
-        let proposal_id2: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id2: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // expire them both
         app.update_block(expire(voting_period));
@@ -850,7 +850,7 @@ mod tests {
         let res = app
             .execute_contract(Addr::unchecked(VOTER2), flex_addr.clone(), &proposal, &[])
             .unwrap();
-        let proposal_id3: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id3: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
         let proposed_at = app.block_info();
 
         // next block, let's query them all... make sure status is properly updated (1 should be rejected in query)
@@ -930,7 +930,7 @@ mod tests {
             .unwrap();
 
         // Get the proposal id from the logs
-        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // Owner cannot vote (again)
         let yes_vote = ExecuteMsg::Vote {
@@ -953,8 +953,8 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER1), flex_addr.clone(), &yes_vote, &[])
             .unwrap();
         assert_eq!(
-            res.attributes,
-            vec![
+            res.custom_attrs(0),
+            &[
                 attr("action", "vote"),
                 attr("sender", VOTER1),
                 attr("proposal_id", proposal_id),
@@ -1006,8 +1006,8 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER4), flex_addr.clone(), &yes_vote, &[])
             .unwrap();
         assert_eq!(
-            res.attributes,
-            vec![
+            res.custom_attrs(0),
+            &[
                 attr("action", "vote"),
                 attr("sender", VOTER4),
                 attr("proposal_id", proposal_id),
@@ -1086,7 +1086,7 @@ mod tests {
             .unwrap();
 
         // Get the proposal id from the logs
-        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // Only Passed can be executed
         let execution = ExecuteMsg::Execute { proposal_id };
@@ -1104,8 +1104,8 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER3), flex_addr.clone(), &vote, &[])
             .unwrap();
         assert_eq!(
-            res.attributes,
-            vec![
+            res.custom_attrs(0),
+            &[
                 attr("action", "vote"),
                 attr("sender", VOTER3),
                 attr("proposal_id", proposal_id),
@@ -1130,8 +1130,8 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            res.attributes,
-            vec![
+            res.custom_attrs(0),
+            &[
                 attr("action", "execute"),
                 attr("sender", SOMEBODY),
                 attr("proposal_id", proposal_id),
@@ -1172,7 +1172,7 @@ mod tests {
             .unwrap();
 
         // Get the proposal id from the logs
-        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // Non-expired proposals cannot be closed
         let closing = ExecuteMsg::Close { proposal_id };
@@ -1187,8 +1187,8 @@ mod tests {
             .execute_contract(Addr::unchecked(SOMEBODY), flex_addr.clone(), &closing, &[])
             .unwrap();
         assert_eq!(
-            res.attributes,
-            vec![
+            res.custom_attrs(0),
+            &[
                 attr("action", "close"),
                 attr("sender", SOMEBODY),
                 attr("proposal_id", proposal_id),
@@ -1224,7 +1224,7 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER1), flex_addr.clone(), &proposal, &[])
             .unwrap();
         // Get the proposal id from the logs
-        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
         let prop_status = |app: &App, proposal_id: u64| -> Status {
             let query_prop = QueryMsg::Proposal { proposal_id };
             let prop: ProposalResponse = app
@@ -1285,7 +1285,7 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER1), flex_addr.clone(), &proposal2, &[])
             .unwrap();
         // Get the proposal id from the logs
-        let proposal_id2: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id2: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // VOTER2 can pass this alone with the updated vote (newer height ignores snapshot)
         let yes_vote = ExecuteMsg::Vote {
@@ -1366,7 +1366,7 @@ mod tests {
             )
             .unwrap();
         // Get the proposal id from the logs
-        let update_proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let update_proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // next block...
         app.update_block(|b| b.height += 1);
@@ -1382,7 +1382,7 @@ mod tests {
             )
             .unwrap();
         // Get the proposal id from the logs
-        let cash_proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let cash_proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
         assert_ne!(cash_proposal_id, update_proposal_id);
 
         // query proposal state
@@ -1475,7 +1475,7 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER3), flex_addr.clone(), &proposal, &[])
             .unwrap();
         // Get the proposal id from the logs
-        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
         let prop_status = |app: &App| -> Status {
             let query_prop = QueryMsg::Proposal { proposal_id };
             let prop: ProposalResponse = app
@@ -1519,7 +1519,7 @@ mod tests {
             .execute_contract(Addr::unchecked(newbie), flex_addr.clone(), &proposal, &[])
             .unwrap();
         // Get the proposal id from the logs
-        let proposal_id2: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id2: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
 
         // check proposal2 status
         let query_prop = QueryMsg::Proposal {
@@ -1557,7 +1557,7 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER3), flex_addr.clone(), &proposal, &[])
             .unwrap();
         // Get the proposal id from the logs
-        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
         let prop_status = |app: &App| -> Status {
             let query_prop = QueryMsg::Proposal { proposal_id };
             let prop: ProposalResponse = app
@@ -1626,7 +1626,7 @@ mod tests {
             .execute_contract(Addr::unchecked(VOTER5), flex_addr.clone(), &proposal, &[])
             .unwrap();
         // Get the proposal id from the logs
-        let proposal_id: u64 = res.attributes[2].value.parse().unwrap();
+        let proposal_id: u64 = res.custom_attrs(0)[2].value.parse().unwrap();
         let prop_status = |app: &App| -> Status {
             let query_prop = QueryMsg::Proposal { proposal_id };
             let prop: ProposalResponse = app

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -405,6 +405,7 @@ mod test {
     use crate::test_helpers::{
         contract_payout, contract_payout_custom, contract_reflect, CustomMsg, EmptyMsg,
         PayoutCountResponse, PayoutInitMessage, PayoutQueryMsg, PayoutSudoMsg, ReflectMessage,
+        ReflectQueryMsg,
     };
     use crate::SimpleBank;
     use cosmwasm_std::testing::MockStorage;
@@ -547,7 +548,7 @@ mod test {
         // reflect count is 1
         let qres: PayoutCountResponse = router
             .wrap()
-            .query_wasm_smart(&reflect_addr, &EmptyMsg {})
+            .query_wasm_smart(&reflect_addr, &ReflectQueryMsg::Count {})
             .unwrap();
         assert_eq!(0, qres.count);
 
@@ -575,7 +576,7 @@ mod test {
         // reflect count updated
         let qres: PayoutCountResponse = router
             .wrap()
-            .query_wasm_smart(&reflect_addr, &EmptyMsg {})
+            .query_wasm_smart(&reflect_addr, &ReflectQueryMsg::Count {})
             .unwrap();
         assert_eq!(1, qres.count);
     }
@@ -622,10 +623,10 @@ mod test {
         let funds = get_balance(&router, &random);
         assert_eq!(funds, coins(7, "eth"));
 
-        // reflect count should be updated to 2
+        // reflect count should be updated to 1
         let qres: PayoutCountResponse = router
             .wrap()
-            .query_wasm_smart(&reflect_addr, &EmptyMsg {})
+            .query_wasm_smart(&reflect_addr, &ReflectQueryMsg::Count {})
             .unwrap();
         assert_eq!(1, qres.count);
 
@@ -653,7 +654,7 @@ mod test {
         // failure should not update reflect count
         let qres: PayoutCountResponse = router
             .wrap()
-            .query_wasm_smart(&reflect_addr, &EmptyMsg {})
+            .query_wasm_smart(&reflect_addr, &ReflectQueryMsg::Count {})
             .unwrap();
         assert_eq!(1, qres.count);
     }

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -758,7 +758,7 @@ mod test {
             messages: vec![msg],
         };
         let _res = router
-            .execute_contract(random.clone(), reflect_addr.clone(), &msgs, &[])
+            .execute_contract(random, reflect_addr.clone(), &msgs, &[])
             .unwrap();
 
         // ensure error was written

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -227,7 +227,7 @@ pub struct AppCache<'a, C>
 where
     C: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
-    router: &'a App<C>,
+    querier: &'a dyn Querier,
     wasm: WasmCache<'a, C>,
     bank: BankCache<'a>,
 }
@@ -253,7 +253,7 @@ where
 {
     fn new(router: &'a App<C>) -> Self {
         AppCache {
-            router,
+            querier: router,
             wasm: router.wasm.cache(),
             bank: router.bank.cache(),
         }
@@ -309,7 +309,7 @@ where
     }
 
     fn sudo(&mut self, contract_addr: Addr, msg: Vec<u8>) -> Result<AppResponse, String> {
-        let res = self.wasm.sudo(contract_addr.clone(), self.router, msg)?;
+        let res = self.wasm.sudo(contract_addr.clone(), self.querier, msg)?;
         let mut attributes = res.attributes;
         let mut events = res.events;
         // recurse in all messages
@@ -343,7 +343,7 @@ where
                 let info = MessageInfo { sender, funds };
                 let res =
                     self.wasm
-                        .execute(contract_addr.clone(), self.router, info, msg.to_vec())?;
+                        .execute(contract_addr.clone(), self.querier, info, msg.to_vec())?;
                 Ok((contract_addr, res))
             }
             WasmMsg::Instantiate {
@@ -360,7 +360,7 @@ where
                 let info = MessageInfo { sender, funds };
                 let mut res = self.wasm.instantiate(
                     contract_addr.clone(),
-                    self.router,
+                    self.querier,
                     info,
                     msg.to_vec(),
                 )?;

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -16,9 +16,17 @@ use std::fmt;
 
 #[derive(Default, Clone, Debug)]
 pub struct AppResponse {
-    pub attributes: Vec<Attribute>,
     pub events: Vec<Event>,
     pub data: Option<Binary>,
+}
+
+impl AppResponse {
+    // Return all custom attributes returned by the contract in the `idx` event.
+    // We assert the type is wasm, and skip the contract_address attribute.
+    pub fn custom_attrs(&self, idx: usize) -> &[Attribute] {
+        assert_eq!(self.events[idx].ty.as_str(), "wasm");
+        &self.events[idx].attributes[1..]
+    }
 }
 
 fn init_response<C>(res: &mut Response<C>, contact_address: &Addr)
@@ -136,14 +144,14 @@ where
     ) -> Result<Addr, String> {
         // instantiate contract
         let init_msg = to_binary(init_msg).map_err(|e| e.to_string())?;
-        let msg = SubMsg::new(WasmMsg::Instantiate {
+        let msg = WasmMsg::Instantiate {
             admin: None,
             code_id,
             msg: init_msg,
             funds: send_funds.to_vec(),
             label: label.into(),
-        });
-        let res = self.execute(sender, msg)?;
+        };
+        let res = self.execute(sender, msg.into())?;
         parse_contract_addr(&res.data)
     }
 
@@ -157,18 +165,18 @@ where
         send_funds: &[Coin],
     ) -> Result<AppResponse, String> {
         let msg = to_binary(msg).map_err(|e| e.to_string())?;
-        let msg = SubMsg::new(WasmMsg::Execute {
+        let msg = WasmMsg::Execute {
             contract_addr: contract_addr.into(),
             msg,
             funds: send_funds.to_vec(),
-        });
-        self.execute(sender, msg)
+        };
+        self.execute(sender, msg.into())
     }
 
     /// Runs arbitrary CosmosMsg.
     /// This will create a cache before the execution, so no state changes are persisted if this
     /// returns an error, but all are persisted on success.
-    pub fn execute(&mut self, sender: Addr, msg: SubMsg<C>) -> Result<AppResponse, String> {
+    pub fn execute(&mut self, sender: Addr, msg: CosmosMsg<C>) -> Result<AppResponse, String> {
         let mut all = self.execute_multi(sender, vec![msg])?;
         let res = all.pop().unwrap();
         Ok(res)
@@ -180,7 +188,7 @@ where
     pub fn execute_multi(
         &mut self,
         sender: Addr,
-        msgs: Vec<SubMsg<C>>,
+        msgs: Vec<CosmosMsg<C>>,
     ) -> Result<Vec<AppResponse>, String> {
         // we need to do some caching of storage here, once in the entry point:
         // meaning, wrap current state, all writes go to a cache, only when execute
@@ -304,69 +312,11 @@ where
         }
     }
 
-    /// This will execute the given messages, making all changes to the local cache.
-    /// This *will* write some data to the cache if the message fails half-way through.
-    /// All sequential calls to RouterCache will be one atomic unit (all commit or all fail).
-    ///
-    /// For normal use cases, you can use Router::execute() or Router::execute_multi().
-    /// This is designed to be handled internally as part of larger process flows.
-    fn execute(&mut self, sender: Addr, msg: SubMsg<C>) -> Result<AppResponse, String> {
-        // execute in cache
-        let mut subtx = self.cache();
-        let res = subtx._execute(sender.clone(), msg.msg);
-        if res.is_ok() {
-            subtx.prepare().commit(self);
-        }
-
-        // call reply if meaningful
-        if let Ok(r) = res {
-            if matches!(msg.reply_on, ReplyOn::Always | ReplyOn::Success) {
-                let reply = Reply {
-                    id: msg.id,
-                    result: ContractResult::Ok(SubMsgExecutionResponse {
-                        events: r.events,
-                        data: r.data,
-                    }),
-                };
-                self._reply(sender, reply)
-            } else {
-                Ok(r)
-            }
-        } else if let Err(e) = res {
-            if matches!(msg.reply_on, ReplyOn::Always | ReplyOn::Error) {
-                let reply = Reply {
-                    id: msg.id,
-                    result: ContractResult::Err(e),
-                };
-                self._reply(sender, reply)
-            } else {
-                Err(e)
-            }
-        } else {
-            res
-        }
-    }
-
-    fn _execute(&mut self, sender: Addr, msg: CosmosMsg<C>) -> Result<AppResponse, String> {
+    pub fn execute(&mut self, sender: Addr, msg: CosmosMsg<C>) -> Result<AppResponse, String> {
         match msg {
             CosmosMsg::Wasm(msg) => {
                 let (resender, res) = self.execute_wasm(sender, msg)?;
-                let mut attributes = res.attributes;
-                let mut events = res.events;
-                // recurse in all messages
-                for resend in res.messages {
-                    let subres = self.execute(resender.clone(), resend)?;
-                    // ignore the data now, just like in wasmd
-                    // append the events
-                    // TODO: is this correct for attributes??? Or do we turn them into sub-events?
-                    attributes.extend_from_slice(&subres.attributes);
-                    events.extend_from_slice(&subres.events);
-                }
-                Ok(AppResponse {
-                    attributes,
-                    events,
-                    data: res.data,
-                })
+                self.process_response(resender, res)
             }
             CosmosMsg::Bank(msg) => {
                 self.bank.execute(sender, msg)?;
@@ -376,45 +326,91 @@ where
         }
     }
 
+    /// This will execute the given messages, making all changes to the local cache.
+    /// This *will* write some data to the cache if the message fails half-way through.
+    /// All sequential calls to RouterCache will be one atomic unit (all commit or all fail).
+    ///
+    /// For normal use cases, you can use Router::execute() or Router::execute_multi().
+    /// This is designed to be handled internally as part of larger process flows.
+    fn execute_submsg(&mut self, contract: Addr, msg: SubMsg<C>) -> Result<AppResponse, String> {
+        // execute in cache
+        let mut subtx = self.cache();
+        let res = subtx.execute(contract.clone(), msg.msg);
+        if res.is_ok() {
+            subtx.prepare().commit(self);
+        }
+
+        // call reply if meaningful
+        if let Ok(r) = res {
+            if matches!(msg.reply_on, ReplyOn::Always | ReplyOn::Success) {
+                let mut orig = r.clone();
+                let reply = Reply {
+                    id: msg.id,
+                    result: ContractResult::Ok(SubMsgExecutionResponse {
+                        events: r.events,
+                        data: r.data,
+                    }),
+                };
+                // do reply and combine it with the original response
+                let res2 = self._reply(contract, reply)?;
+                // override data if set
+                if let Some(data) = res2.data {
+                    orig.data = Some(data);
+                }
+                // append the events
+                orig.events.extend_from_slice(&res2.events);
+                Ok(orig)
+            } else {
+                Ok(r)
+            }
+        } else if let Err(e) = res {
+            if matches!(msg.reply_on, ReplyOn::Always | ReplyOn::Error) {
+                let reply = Reply {
+                    id: msg.id,
+                    result: ContractResult::Err(e),
+                };
+                self._reply(contract, reply)
+            } else {
+                Err(e)
+            }
+        } else {
+            res
+        }
+    }
+
     fn _reply(&mut self, contract: Addr, reply: Reply) -> Result<AppResponse, String> {
         // TODO: process result better, combine events / data from parent
         let res = self.wasm.reply(contract.clone(), self.querier, reply)?;
-        let mut attributes = res.attributes;
-        let mut events = res.events;
+        self.process_response(contract, res)
+    }
+
+    fn process_response(
+        &mut self,
+        contract: Addr,
+        response: Response<C>,
+    ) -> Result<AppResponse, String> {
+        let mut events = response.events;
+        // turn attributes into event and place it first
+        let mut wasm_event = Event::new("wasm").attr("contract_address", &contract);
+        wasm_event
+            .attributes
+            .extend_from_slice(&response.attributes);
+        events.insert(0, wasm_event);
+
         // recurse in all messages
-        for resend in res.messages {
-            let subres = self.execute(contract.clone(), resend)?;
-            // ignore the data now, just like in wasmd
-            // append the events
-            // TODO: is this correct for attributes??? Or do we turn them into sub-events?
-            attributes.extend_from_slice(&subres.attributes);
+        for resend in response.messages {
+            let subres = self.execute_submsg(contract.clone(), resend)?;
             events.extend_from_slice(&subres.events);
         }
         Ok(AppResponse {
-            attributes,
             events,
-            data: res.data,
+            data: response.data,
         })
     }
 
     fn sudo(&mut self, contract_addr: Addr, msg: Vec<u8>) -> Result<AppResponse, String> {
         let res = self.wasm.sudo(contract_addr.clone(), self.querier, msg)?;
-        let mut attributes = res.attributes;
-        let mut events = res.events;
-        // recurse in all messages
-        for resend in res.messages {
-            let subres = self.execute(contract_addr.clone(), resend)?;
-            // ignore the data now, just like in wasmd
-            // append the events
-            // TODO: is this correct for attributes??? Or do we turn them into sub-events?
-            attributes.extend_from_slice(&subres.attributes);
-            events.extend_from_slice(&subres.events);
-        }
-        Ok(AppResponse {
-            attributes,
-            events,
-            data: res.data,
-        })
+        self.process_response(contract_addr, res)
     }
 
     // this returns the contract address as well, so we can properly resend the data
@@ -538,10 +534,11 @@ mod test {
 
         // send both tokens
         let to_send = vec![coin(30, "eth"), coin(5, "btc")];
-        let msg = SubMsg::new(BankMsg::Send {
+        let msg: CosmosMsg = BankMsg::Send {
             to_address: rcpt.clone().into(),
             amount: to_send,
-        });
+        }
+        .into();
         router.execute(owner.clone(), msg.clone()).unwrap();
         let rich = get_balance(&router, &owner);
         assert_eq!(vec![coin(15, "btc"), coin(70, "eth")], rich);
@@ -552,10 +549,11 @@ mod test {
         router.execute(rcpt.clone(), msg).unwrap();
 
         // cannot send too much
-        let msg = SubMsg::new(BankMsg::Send {
+        let msg = BankMsg::Send {
             to_address: rcpt.into(),
             amount: coins(20, "btc"),
-        });
+        }
+        .into();
         router.execute(owner.clone(), msg).unwrap_err();
 
         let rich = get_balance(&router, &owner);
@@ -596,8 +594,9 @@ mod test {
         let res = router
             .execute_contract(random.clone(), contract_addr.clone(), &EmptyMsg {}, &[])
             .unwrap();
-        assert_eq!(1, res.attributes.len());
-        assert_eq!(&attr("action", "payout"), &res.attributes[0]);
+        assert_eq!(1, res.events.len());
+        let custom_attrs = res.custom_attrs(0);
+        assert_eq!(&[attr("action", "payout")], &custom_attrs);
 
         // random got cash
         let funds = get_balance(&router, &random);
@@ -643,7 +642,7 @@ mod test {
 
         // reflecting payout message pays reflect contract
         let msg = SubMsg::new(WasmMsg::Execute {
-            contract_addr: payout_addr.into(),
+            contract_addr: payout_addr.clone().into(),
             msg: b"{}".into(),
             funds: vec![],
         });
@@ -655,8 +654,25 @@ mod test {
             .unwrap();
 
         // ensure the attributes were relayed from the sub-message
-        assert_eq!(1, res.attributes.len());
-        assert_eq!(&attr("action", "payout"), &res.attributes[0]);
+        assert_eq!(2, res.events.len(), "{:?}", res.events);
+        // first event was the call to reflect
+        let first = &res.events[0];
+        assert_eq!(first.ty.as_str(), "wasm");
+        assert_eq!(1, first.attributes.len());
+        assert_eq!(
+            &attr("contract_address", &reflect_addr),
+            &first.attributes[0]
+        );
+        // second event was call to payout
+        let second = &res.events[1];
+        assert_eq!(second.ty.as_str(), "wasm");
+        assert_eq!(2, second.attributes.len());
+        assert_eq!(
+            &attr("contract_address", &payout_addr),
+            &second.attributes[0]
+        );
+        assert_eq!(&attr("action", "payout"), &second.attributes[1]);
+        // FIXME? reply didn't add any more events itself...
 
         // ensure transfer was executed with reflect as sender
         let funds = get_balance(&router, &reflect_addr);
@@ -707,7 +723,11 @@ mod test {
         let res = router
             .execute_contract(random.clone(), reflect_addr.clone(), &msgs, &[])
             .unwrap();
-        assert_eq!(0, res.attributes.len());
+        // only one wasm event with no custom attributes
+        assert_eq!(1, res.events.len());
+        assert_eq!(1, res.events[0].attributes.len());
+        assert_eq!("wasm", res.events[0].ty.as_str());
+        assert_eq!("contract_address", res.events[0].attributes[0].key.as_str());
         // ensure random got paid
         let funds = get_balance(&router, &random);
         assert_eq!(funds, coins(7, "eth"));

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -77,6 +77,13 @@ impl<'a> BankCache<'a> {
         }
     }
 
+    pub fn cache(&self) -> BankCache {
+        BankCache {
+            bank: self.bank,
+            state: StorageTransaction::new(&self.state),
+        }
+    }
+
     /// When we want to commit the BankCache, we need a 2 step process to satisfy Rust reference counting:
     /// 1. prepare() consumes BankCache, releasing &BankRouter, and creating a self-owned update info.
     /// 2. BankOps::commit() can now take &mut BankRouter and updates the underlying state

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -63,9 +63,14 @@ pub struct BankCache<'a> {
 
 pub struct BankOps(RepLog);
 
+// TODO: combine these into one function that takes both
 impl BankOps {
     pub fn commit(self, router: &mut BankRouter) {
         self.0.commit(router.storage.as_mut())
+    }
+
+    pub fn commit_cache(self, cache: &mut BankCache) {
+        self.0.commit(&mut cache.state)
     }
 }
 
@@ -93,6 +98,10 @@ impl<'a> BankCache<'a> {
 
     pub fn execute(&mut self, sender: Addr, msg: BankMsg) -> Result<(), String> {
         self.bank.execute(&mut self.state, sender, msg)
+    }
+
+    pub fn query(&self, request: BankQuery) -> Result<Binary, String> {
+        self.bank.query(&self.state, request)
     }
 }
 
@@ -313,7 +322,7 @@ mod test {
         let bank = SimpleBank {};
         bank.set_balance(&mut store, &owner, init_funds).unwrap();
 
-        // send both tokens
+        // burn both tokens
         let to_burn = vec![coin(30, "eth"), coin(5, "btc")];
         let msg = BankMsg::Burn { amount: to_burn };
         bank.execute(&mut store, owner.clone(), msg).unwrap();
@@ -335,5 +344,76 @@ mod test {
         };
         let err = bank.execute(&mut store, rcpt, msg).unwrap_err();
         assert!(err.contains("Overflow"));
+    }
+
+    fn query_cache(cache: &BankCache, rcpt: &Addr) -> Vec<Coin> {
+        let query = BankQuery::AllBalances {
+            address: rcpt.into(),
+        };
+        let res = cache.query(query.clone()).unwrap();
+        let val: AllBalanceResponse = from_slice(&res).unwrap();
+        val.amount
+    }
+
+    fn query_router(cache: &BankRouter, rcpt: &Addr) -> Vec<Coin> {
+        let query = BankQuery::AllBalances {
+            address: rcpt.into(),
+        };
+        let res = cache.query(query.clone()).unwrap();
+        let val: AllBalanceResponse = from_slice(&res).unwrap();
+        val.amount
+    }
+
+    #[test]
+    fn multi_level_bank_cache() {
+        let mut store = MockStorage::new();
+
+        let owner = Addr::unchecked("owner");
+        let rcpt = Addr::unchecked("recipient");
+        let init_funds = vec![coin(20, "btc"), coin(100, "eth")];
+
+        // set money
+        let bank = SimpleBank {};
+        bank.set_balance(&mut store, &owner, init_funds).unwrap();
+        let mut router = BankRouter::new(bank, Box::new(store));
+
+        // cache 1 - send some tokens
+        let mut cache = router.cache();
+        let msg = BankMsg::Send {
+            to_address: rcpt.clone().into(),
+            amount: coins(25, "eth"),
+        };
+        cache.execute(owner.clone(), msg).unwrap();
+
+        // shows up in cache
+        let cached_rcpt = query_cache(&cache, &rcpt);
+        assert_eq!(coins(25, "eth"), cached_rcpt);
+        let router_rcpt = query_router(&router, &rcpt);
+        assert_eq!(router_rcpt, vec![]);
+
+        // now, second level cache
+        let mut cache2 = cache.cache();
+        let msg = BankMsg::Send {
+            to_address: rcpt.clone().into(),
+            amount: coins(12, "eth"),
+        };
+        cache2.execute(owner.clone(), msg).unwrap();
+
+        // shows up in 2nd cache
+        let cached_rcpt = query_cache(&cache, &rcpt);
+        assert_eq!(coins(25, "eth"), cached_rcpt);
+        let cached2_rcpt = query_cache(&cache2, &rcpt);
+        assert_eq!(coins(37, "eth"), cached2_rcpt);
+
+        // apply second to first
+        let ops = cache2.prepare();
+        ops.commit_cache(&mut cache);
+
+        // apply first to router
+        let ops = cache.prepare();
+        ops.commit(&mut router);
+
+        let committed = query_router(&router, &rcpt);
+        assert_eq!(coins(37, "eth"), committed);
     }
 }

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -57,7 +57,7 @@ impl BankRouter {
 
 pub struct BankCache<'a> {
     // and this into one with reference
-    router: &'a BankRouter,
+    bank: &'a dyn Bank,
     state: StorageTransaction<'a>,
 }
 
@@ -72,7 +72,7 @@ impl BankOps {
 impl<'a> BankCache<'a> {
     fn new(router: &'a BankRouter) -> Self {
         BankCache {
-            router,
+            bank: router.bank.as_ref(),
             state: StorageTransaction::new(router.storage.as_ref()),
         }
     }
@@ -85,7 +85,7 @@ impl<'a> BankCache<'a> {
     }
 
     pub fn execute(&mut self, sender: Addr, msg: BankMsg) -> Result<(), String> {
-        self.router.bank.execute(&mut self.state, sender, msg)
+        self.bank.execute(&mut self.state, sender, msg)
     }
 }
 

--- a/packages/multi-test/src/test_helpers.rs
+++ b/packages/multi-test/src/test_helpers.rs
@@ -53,18 +53,37 @@ where
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct PayoutMessage {
+pub struct PayoutInitMessage {
     pub payout: Coin,
 }
-const PAYOUT: Item<PayoutMessage> = Item::new("payout");
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PayoutSudoMsg {
+    pub set_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PayoutQueryMsg {
+    Count {},
+    Payout {},
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PayoutCountResponse {
+    pub count: u32,
+}
+
+const PAYOUT: Item<PayoutInitMessage> = Item::new("payout");
+const COUNT: Item<u32> = Item::new("count");
 
 fn instantiate_payout(
     deps: DepsMut,
     _env: Env,
     _info: MessageInfo,
-    msg: PayoutMessage,
+    msg: PayoutInitMessage,
 ) -> Result<Response, StdError> {
     PAYOUT.save(deps.storage, &msg)?;
+    COUNT.save(deps.storage, &1)?;
     Ok(Response::default())
 }
 
@@ -89,13 +108,32 @@ fn execute_payout(
     Ok(res)
 }
 
-fn query_payout(deps: Deps, _env: Env, _msg: EmptyMsg) -> Result<Binary, StdError> {
-    let payout = PAYOUT.load(deps.storage)?;
-    to_binary(&payout)
+fn sudo_payout(deps: DepsMut, _env: Env, msg: PayoutSudoMsg) -> Result<Response, StdError> {
+    COUNT.save(deps.storage, &msg.set_count)?;
+    Ok(Response::default())
+}
+
+fn query_payout(deps: Deps, _env: Env, msg: PayoutQueryMsg) -> Result<Binary, StdError> {
+    match msg {
+        PayoutQueryMsg::Count {} => {
+            let count = COUNT.load(deps.storage)?;
+            let res = PayoutCountResponse { count };
+            to_binary(&res)
+        }
+        PayoutQueryMsg::Payout {} => {
+            let payout = PAYOUT.load(deps.storage)?;
+            to_binary(&payout)
+        }
+    }
 }
 
 pub fn contract_payout() -> Box<dyn Contract<Empty>> {
-    let contract = ContractWrapper::new(execute_payout, instantiate_payout, query_payout);
+    let contract = ContractWrapper::new_with_sudo(
+        execute_payout,
+        instantiate_payout,
+        query_payout,
+        sudo_payout,
+    );
     Box::new(contract)
 }
 
@@ -117,21 +155,9 @@ pub enum CustomMsg {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ReflectSudoMsg {
-    pub set_count: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ReflectMessage {
     pub messages: Vec<SubMsg<CustomMsg>>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ReflectResponse {
-    pub count: u32,
-}
-
-const REFLECT: Item<u32> = Item::new("reflect");
 
 fn instantiate_reflect(
     deps: DepsMut,
@@ -139,7 +165,7 @@ fn instantiate_reflect(
     _info: MessageInfo,
     _msg: EmptyMsg,
 ) -> Result<Response<CustomMsg>, StdError> {
-    REFLECT.save(deps.storage, &1)?;
+    COUNT.save(deps.storage, &0)?;
     Ok(Response::default())
 }
 
@@ -149,7 +175,7 @@ fn execute_reflect(
     _info: MessageInfo,
     msg: ReflectMessage,
 ) -> Result<Response<CustomMsg>, StdError> {
-    REFLECT.update::<_, StdError>(deps.storage, |old| Ok(old + 1))?;
+    COUNT.update::<_, StdError>(deps.storage, |old| Ok(old + 1))?;
 
     let res = Response {
         messages: msg.messages,
@@ -160,27 +186,13 @@ fn execute_reflect(
     Ok(res)
 }
 
-fn sudo_reflect(
-    deps: DepsMut,
-    _env: Env,
-    msg: ReflectSudoMsg,
-) -> Result<Response<CustomMsg>, StdError> {
-    REFLECT.save(deps.storage, &msg.set_count)?;
-    Ok(Response::default())
-}
-
 fn query_reflect(deps: Deps, _env: Env, _msg: EmptyMsg) -> Result<Binary, StdError> {
-    let count = REFLECT.load(deps.storage)?;
-    let res = ReflectResponse { count };
+    let count = COUNT.load(deps.storage)?;
+    let res = PayoutCountResponse { count };
     to_binary(&res)
 }
 
 pub fn contract_reflect() -> Box<dyn Contract<CustomMsg>> {
-    let contract = ContractWrapper::new_with_sudo(
-        execute_reflect,
-        instantiate_reflect,
-        query_reflect,
-        sudo_reflect,
-    );
+    let contract = ContractWrapper::new(execute_reflect, instantiate_reflect, query_reflect);
     Box::new(contract)
 }

--- a/packages/multi-test/src/test_helpers.rs
+++ b/packages/multi-test/src/test_helpers.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use cosmwasm_std::{
-    attr, to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Empty, Env, MessageInfo, Reply,
+    attr, to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Empty, Env, Event, MessageInfo, Reply,
     Response, StdError, SubMsg,
 };
 use cw_storage_plus::{Item, Map, U64Key};
@@ -210,7 +210,14 @@ fn query_reflect(deps: Deps, _env: Env, msg: ReflectQueryMsg) -> Result<Binary, 
 
 fn reply_reflect(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response<CustomMsg>, StdError> {
     REFLECT.save(deps.storage, msg.id.into(), &msg)?;
-    Ok(Response::default())
+    // add custom event here to test
+    let event = Event::new("custom")
+        .attr("from", "reply")
+        .attr("to", "test");
+    Ok(Response {
+        events: vec![event],
+        ..Response::default()
+    })
 }
 
 pub fn contract_reflect() -> Box<dyn Contract<CustomMsg>> {

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -263,7 +263,7 @@ where
         res.map_err(|e| e.to_string())
     }
 
-    // this returns an error if the contract doesn't implement sudo
+    // this returns an error if the contract doesn't implement reply
     fn reply(&self, deps: DepsMut, env: Env, reply_data: Reply) -> Result<Response<C>, String> {
         let res = match &self.reply_fn {
             Some(reply) => reply(deps, env, reply_data),

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -289,14 +289,14 @@ impl ContractData {
         ContractData { code_id, storage }
     }
 
-    fn as_mut<'a>(&'a mut self) -> ContractMut<'a> {
+    fn as_mut(&mut self) -> ContractMut {
         ContractMut {
             code_id: self.code_id,
             storage: self.storage.as_mut(),
         }
     }
 
-    fn as_ref<'a>(&'a self) -> ContractRef<'a> {
+    fn as_ref(&self) -> ContractRef {
         ContractRef {
             code_id: self.code_id,
             storage: self.storage.as_ref(),
@@ -587,7 +587,7 @@ where
         }
     }
 
-    pub fn cache<'b>(&'b self) -> WasmCache<'b, C> {
+    pub fn cache(&self) -> WasmCache<C> {
         WasmCache {
             router: self.router,
             parent_contracts: self,
@@ -911,8 +911,8 @@ mod test {
     }
 
     fn assert_no_contract(cache: &WasmCache<Empty>, contract_addr: &Addr) {
-        let foo = cache.get_contract(contract_addr);
-        assert!(foo.is_none(), "{:?}", contract_addr);
+        let contract = cache.get_contract(contract_addr);
+        assert!(contract.is_none(), "{:?}", contract_addr);
     }
 
     #[test]

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -658,7 +658,7 @@ impl<'a> WasmCacheState<'a> {
 mod test {
     use super::*;
 
-    use crate::test_helpers::{contract_error, contract_payout, PayoutMessage};
+    use crate::test_helpers::{contract_error, contract_payout, PayoutInitMessage, PayoutQueryMsg};
     use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{coin, to_vec, BankMsg, BlockInfo, CosmosMsg, Empty};
 
@@ -731,7 +731,7 @@ mod test {
 
         // init the contract
         let info = mock_info("foobar", &[]);
-        let init_msg = to_vec(&PayoutMessage {
+        let init_msg = to_vec(&PayoutInitMessage {
             payout: payout.clone(),
         })
         .unwrap();
@@ -758,10 +758,9 @@ mod test {
         cache.prepare().commit(&mut router);
 
         // query the contract
-        let data = router
-            .query_smart(contract_addr, &querier, b"{}".to_vec())
-            .unwrap();
-        let res: PayoutMessage = from_slice(&data).unwrap();
+        let query = to_vec(&PayoutQueryMsg::Payout {}).unwrap();
+        let data = router.query_smart(contract_addr, &querier, query).unwrap();
+        let res: PayoutInitMessage = from_slice(&data).unwrap();
         assert_eq!(res.payout, payout);
     }
 }

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -674,6 +674,32 @@ where
         )
     }
 
+    pub fn reply(
+        &mut self,
+        address: Addr,
+        querier: &dyn Querier,
+        reply: Reply,
+    ) -> Result<Response<C>, String> {
+        // this errors if the sender is not a contract
+        let parent = &self.router.codes;
+        let env = self.router.get_env(address.clone());
+        let api = self.router.api.as_ref();
+
+        self.state.with_storage(
+            querier,
+            self.parent_contracts,
+            address,
+            env,
+            api,
+            |code_id, deps, env| {
+                let handler = parent
+                    .get(&code_id)
+                    .ok_or_else(|| "Unregistered code id".to_string())?;
+                handler.reply(deps, env, reply)
+            },
+        )
+    }
+
     pub fn sudo(
         &mut self,
         address: Addr,

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -42,7 +42,7 @@ where
 type ContractFn<T, C, E> =
     fn(deps: DepsMut, env: Env, info: MessageInfo, msg: T) -> Result<Response<C>, E>;
 type SudoFn<T, C, E> = fn(deps: DepsMut, env: Env, msg: T) -> Result<Response<C>, E>;
-// type ReplyFn<C, E> = fn(deps: DepsMut, env: Env, msg: Reply) -> Result<Response<C>, E>;
+type ReplyFn<C, E> = fn(deps: DepsMut, env: Env, msg: Reply) -> Result<Response<C>, E>;
 type QueryFn<T, E> = fn(deps: Deps, env: Env, msg: T) -> Result<Binary, E>;
 
 type ContractClosure<T, C, E> = Box<dyn Fn(DepsMut, Env, MessageInfo, T) -> Result<Response<C>, E>>;
@@ -137,6 +137,33 @@ where
             query_fn: Box::new(query_fn),
             sudo_fn: Some(Box::new(sudo_fn)),
             reply_fn: None,
+        }
+    }
+}
+
+impl<T1, T2, T3, E1, E2, E3, C, E5> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Empty, String, E5>
+where
+    T1: DeserializeOwned + 'static,
+    T2: DeserializeOwned + 'static,
+    T3: DeserializeOwned + 'static,
+    E1: ToString + 'static,
+    E2: ToString + 'static,
+    E3: ToString + 'static,
+    E5: ToString + 'static,
+    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+{
+    pub fn new_with_reply(
+        execute_fn: ContractFn<T1, C, E1>,
+        instantiate_fn: ContractFn<T2, C, E2>,
+        query_fn: QueryFn<T3, E3>,
+        reply_fn: ReplyFn<C, E5>,
+    ) -> Self {
+        ContractWrapper {
+            execute_fn: Box::new(execute_fn),
+            instantiate_fn: Box::new(instantiate_fn),
+            query_fn: Box::new(query_fn),
+            sudo_fn: None,
+            reply_fn: Some(Box::new(reply_fn)),
         }
     }
 }


### PR DESCRIPTION
Closes #259 

- [x] Add optional `reply` to contract wrapper contructor
- [x] Add sample contract that handles submessages
- [x] Add (failing) submessage tests
- [x] Support submessages