### PR TITLE
Refactor of cw1-whitelist unit tests

### DIFF
--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+test-utils = []
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.7.0" }
@@ -30,3 +31,4 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.15.0" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.7.0", features = ["library", "test-utils"] }

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -651,7 +651,7 @@ mod tests {
 
         // Check allowances work for accounts with no balance
         let allowance = query_allowance(deps.as_ref(), SPENDER3.to_string()).unwrap();
-        assert_eq!(allowance, Allowance::default(),);
+        assert_eq!(allowance, Allowance::default());
     }
 
     #[test]

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -590,7 +590,7 @@ mod tests {
     }
 
     /// Helper function for comparing vectors or another slice-like object as they would represent
-    /// set with duplications. Compares sets by first sorting elements usning provided ordering.
+    /// set with duplications. Compares sets by first sorting elements using provided ordering.
     /// This functions reshufless elements inplace, as it should never matter as compared
     /// containers should represent same value regardless of ordering, and making this inplace just
     /// safes obsolete copying.

--- a/contracts/cw1-subkeys/src/msg.rs
+++ b/contracts/cw1-subkeys/src/msg.rs
@@ -88,10 +88,81 @@ pub struct AllowanceInfo {
     pub expires: Expiration,
 }
 
+#[cfg(test)]
+impl AllowanceInfo {
+    /// Utility function providing some ordering to be used with `slice::sort_by`.
+    ///
+    /// Note, that this doesn't implement full ordering - items with same spender but differing on
+    /// permissions, would be considered equal, however as spender is a unique key in any valid
+    /// state this is enough for testing purposes.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// # use cw0::{Expiration, NativeBalance};
+    /// # use cw1_subkeys::msg::AllowanceInfo;
+    /// # use cosmwasm_std::coin;
+    ///
+    /// let mut allows = vec![AllowanceInfo {
+    ///   spender: "spender2".to_owned(),
+    ///   balance: NativeBalance(vec![coin(1, "token1")]),
+    ///   expires: Expiration::Never {},
+    /// }, AllowanceInfo {
+    ///   spender: "spender1".to_owned(),
+    ///   balance: NativeBalance(vec![coin(2, "token2")]),
+    ///   expires: Expiration::Never {},
+    /// }];
+    ///
+    /// allows.sort_by(AllowanceInfo::cmp_by_spender);
+    ///
+    /// assert_eq!(
+    ///   allows.into_iter().map(|allow| allow.spender).collect::<Vec<_>>(),
+    ///   vec!["spender1".to_owned(), "spender2".to_owned()]
+    /// );
+    /// ```
+    pub fn cmp_by_spender(left: &Self, right: &Self) -> std::cmp::Ordering {
+        left.spender.cmp(&right.spender)
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct PermissionsInfo {
     pub spender: String,
     pub permissions: Permissions,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl PermissionsInfo {
+    /// Utility function providing some ordering to be used with `slice::sort_by`.
+    ///
+    /// Note, that this doesn't implement full ordering - items with same spender but differing on
+    /// permissions, would be considered equal, however as spender is a unique key in any valid
+    /// state this is enough for testing purposes.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// # use cw1_subkeys::msg::PermissionsInfo;
+    /// # use cw1_subkeys::state::Permissions;
+    ///
+    /// let mut perms = vec![PermissionsInfo {
+    ///   spender: "spender2".to_owned(),
+    ///   permissions: Permissions::default(),
+    /// }, PermissionsInfo {
+    ///   spender: "spender1".to_owned(),
+    ///   permissions: Permissions::default(),
+    /// }];
+    ///
+    /// perms.sort_by(PermissionsInfo::cmp_by_spender);
+    ///
+    /// assert_eq!(
+    ///   perms.into_iter().map(|perm| perm.spender).collect::<Vec<_>>(),
+    ///   vec!["spender1".to_owned(), "spender2".to_owned()]
+    /// );
+    /// ```
+    pub fn cmp_by_spender(left: &Self, right: &Self) -> std::cmp::Ordering {
+        left.spender.cmp(&right.spender)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/cw1-subkeys/src/msg.rs
+++ b/contracts/cw1-subkeys/src/msg.rs
@@ -81,6 +81,19 @@ pub struct AllAllowancesResponse {
     pub allowances: Vec<AllowanceInfo>,
 }
 
+#[cfg(test)]
+impl AllAllowancesResponse {
+    pub fn canonical(mut self) -> Self {
+        self.allowances = self
+            .allowances
+            .into_iter()
+            .map(AllowanceInfo::canonical)
+            .collect();
+        self.allowances.sort_by(AllowanceInfo::cmp_by_spender);
+        self
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct AllowanceInfo {
     pub spender: String,
@@ -122,6 +135,11 @@ impl AllowanceInfo {
     /// ```
     pub fn cmp_by_spender(left: &Self, right: &Self) -> std::cmp::Ordering {
         left.spender.cmp(&right.spender)
+    }
+
+    pub fn canonical(mut self) -> Self {
+        self.balance.normalize();
+        self
     }
 }
 

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -36,7 +36,7 @@ pub struct Allowance {
 
 #[cfg(test)]
 impl Allowance {
-    /// Utility function forconverting message to its canonical form, so two messages with
+    /// Utility function for converting message to its canonical form, so two messages with
     /// different representation but same semantical meaning can be easly compared.
     ///
     /// It could be encapsulated in custom `PartialEq` implementation, but `PartialEq` is expected

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -37,7 +37,7 @@ pub struct Allowance {
 #[cfg(test)]
 impl Allowance {
     /// Utility function for converting message to its canonical form, so two messages with
-    /// different representation but same semantical meaning can be easly compared.
+    /// different representation but same semantic meaning can be easily compared.
     ///
     /// It could be encapsulated in custom `PartialEq` implementation, but `PartialEq` is expected
     /// to be fast, so it seems to be reasonable to keep it as representation-equality, and

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -34,5 +34,38 @@ pub struct Allowance {
     pub expires: Expiration,
 }
 
+impl Allowance {
+    /// Utility function forconverting message to its canonical form, so two messages with
+    /// different representation but same semantical meaning can be easly compared.
+    ///
+    /// It could be encapsulated in custom `PartialEq` implementation, but `PartialEq` is expected
+    /// to be quickly, so it seems to be reasonable to keep it as representation-equality, and
+    /// canonicalize message only when it is needed
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// # use cw0::{Expiration, NativeBalance};
+    /// # use cw1_subkeys::state::Allowance;
+    /// # use cosmwasm_std::coin;
+    ///
+    /// let allow1 = Allowance {
+    ///   balance: NativeBalance(vec![coin(1, "token1"), coin(0, "token2"), coin(2, "token1"), coin(3, "token3")]),
+    ///   expires: Expiration::Never {},
+    /// };
+    ///
+    /// let allow2 = Allowance {
+    ///   balance: NativeBalance(vec![coin(3, "token3"), coin(3, "token1")]),
+    ///   expires: Expiration::Never {},
+    /// };
+    ///
+    /// assert_eq!(allow1.canonical(), allow2.canonical());
+    /// ```
+    pub fn canonical(mut self) -> Self {
+        self.balance.normalize();
+        self
+    }
+}
+
 pub const PERMISSIONS: Map<&Addr, Permissions> = Map::new("permissions");
 pub const ALLOWANCES: Map<&Addr, Allowance> = Map::new("allowances");

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -34,6 +34,7 @@ pub struct Allowance {
     pub expires: Expiration,
 }
 
+#[cfg(test)]
 impl Allowance {
     /// Utility function forconverting message to its canonical form, so two messages with
     /// different representation but same semantical meaning can be easly compared.

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -40,7 +40,7 @@ impl Allowance {
     /// different representation but same semantical meaning can be easly compared.
     ///
     /// It could be encapsulated in custom `PartialEq` implementation, but `PartialEq` is expected
-    /// to be quickly, so it seems to be reasonable to keep it as representation-equality, and
+    /// to be fast, so it seems to be reasonable to keep it as representation-equality, and
     /// canonicalize message only when it is needed
     ///
     /// Example:

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+test-utils = []
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.7.0" }

--- a/contracts/cw1-whitelist/src/msg.rs
+++ b/contracts/cw1-whitelist/src/msg.rs
@@ -47,6 +47,7 @@ pub struct AdminListResponse {
     pub mutable: bool,
 }
 
+#[cfg(any(test, feature = "test-utils"))]
 impl AdminListResponse {
     /// Utility function forconverting message to its canonical form, so two messages with
     /// different representation but same semantical meaning can be easly compared.

--- a/contracts/cw1-whitelist/src/msg.rs
+++ b/contracts/cw1-whitelist/src/msg.rs
@@ -46,3 +46,35 @@ pub struct AdminListResponse {
     pub admins: Vec<String>,
     pub mutable: bool,
 }
+
+impl AdminListResponse {
+    /// Utility function forconverting message to its canonical form, so two messages with
+    /// different representation but same semantical meaning can be easly compared.
+    ///
+    /// It could be encapsulated in custom `PartialEq` implementation, but `PartialEq` is expected
+    /// to be quickly, so it seems to be reasonable to keep it as representation-equality, and
+    /// canonicalize message only when it is needed
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// # use cw1_whitelist::msg::AdminListResponse;
+    ///
+    /// let resp1 = AdminListResponse {
+    ///   admins: vec!["admin1".to_owned(), "admin2".to_owned()],
+    ///   mutable: true,
+    /// };
+    ///
+    /// let resp2 = AdminListResponse {
+    ///   admins: vec!["admin2".to_owned(), "admin1".to_owned(), "admin2".to_owned()],
+    ///   mutable: true,
+    /// };
+    ///
+    /// assert_eq!(resp1.canonical(), resp2.canonical());
+    /// ```
+    pub fn canonical(mut self) -> Self {
+        self.admins.sort();
+        self.admins.dedup();
+        self
+    }
+}


### PR DESCRIPTION
As there is a request to create additional UTs for some contracts: https://github.com/CosmWasm/cosmwasm-plus/issues/105, I went through the whitelist contract UT and found that kind of problem with adding many tests there is repetitive boilerplate in every test, which is not actually easy to read. Also because of some edge cases, some test may be actually incorrect (eg. if in future some items would be returned in different order because of any reason, UTs would start failing - while ordering in many cases shouldn't matter).

Therefore I came up with proposal to kind of unify the UTs structure to have visible setup => execute => verify structure, with - what is important - clear setup, so it is easier to figure out what is the test about.

Additional changes I am considering to make execution and possibly verify part simpler is to add `execute`/`query` methods directly on `Suite` (query via router), so the `deps` and `mock_env` are hidden. Additionally it would make testing queries through whole ecosystem, not just locally which might be more complete.

At the end I think, that the `Suite` structure could be partially generalized and extracted to `multi-test`, to encourage having clean an uniform test through the smart contracts.