### PR TITLE
Implemented expiration for cw1-subkeys contract

### DIFF
--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -6,7 +6,7 @@ use std::ops::{AddAssign, Sub};
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     attr, to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, DistributionMsg, Empty, Env,
-    MessageInfo, Order, Response, StakingMsg, StdError, StdResult, SubMsg,
+    MessageInfo, Order, Response, StakingMsg, StdResult, SubMsg,
 };
 use cw0::Expiration;
 use cw1::CanExecuteResponse;
@@ -76,7 +76,7 @@ pub fn execute(
 
 pub fn execute_execute<T>(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     msgs: Vec<CosmosMsg<T>>,
 ) -> Result<Response<T>, ContractError>
@@ -107,6 +107,10 @@ where
                 }) => {
                     ALLOWANCES.update::<_, ContractError>(deps.storage, &info.sender, |allow| {
                         let mut allowance = allow.ok_or(ContractError::NoAllowance {})?;
+                        if is_expired(&env, allowance.expires) {
+                            return Err(ContractError::NoAllowance {});
+                        }
+
                         // Decrease allowance
                         allowance.balance = allowance.balance.sub(amount.clone())?;
                         Ok(allowance)
@@ -125,6 +129,14 @@ where
         ..Response::default()
     };
     Ok(res)
+}
+
+pub fn is_expired(env: &Env, expire: Expiration) -> bool {
+    match expire {
+        Expiration::AtTime(timestamp) => timestamp <= env.block.time,
+        Expiration::AtHeight(height) => height < env.block.height,
+        _ => false,
+    }
 }
 
 pub fn check_staking_permissions(
@@ -174,7 +186,7 @@ pub fn check_distribution_permissions(
 
 pub fn execute_increase_allowance<T>(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     spender: String,
     amount: Coin,
@@ -193,11 +205,19 @@ where
         return Err(ContractError::CannotSetOwnAccount {});
     }
 
-    ALLOWANCES.update::<_, StdError>(deps.storage, &spender_addr, |allow| {
-        let mut allowance = allow.unwrap_or_default();
+    ALLOWANCES.update::<_, ContractError>(deps.storage, &spender_addr, |allow| {
+        let mut allowance = allow
+            .filter(|allow| !is_expired(&env, allow.expires))
+            .unwrap_or_default();
+
         if let Some(exp) = expires {
+            if is_expired(&env, exp) {
+                return Err(ContractError::SettingExpiredAllowance(exp));
+            }
+
             allowance.expires = exp;
         }
+
         allowance.balance.add_assign(amount.clone());
         Ok(allowance)
     })?;
@@ -217,7 +237,7 @@ where
 
 pub fn execute_decrease_allowance<T>(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     spender: String,
     amount: Coin,
@@ -239,13 +259,22 @@ where
     let allowance =
         ALLOWANCES.update::<_, ContractError>(deps.storage, &spender_addr, |allow| {
             // Fail fast
-            let mut allowance = allow.ok_or(ContractError::NoAllowance {})?;
+            let mut allowance = allow
+                .filter(|allow| !is_expired(&env, allow.expires))
+                .ok_or(ContractError::NoAllowance {})?;
+
             if let Some(exp) = expires {
+                if is_expired(&env, exp) {
+                    return Err(ContractError::SettingExpiredAllowance(exp));
+                }
+
                 allowance.expires = exp;
             }
+
             allowance.balance = allowance.balance.sub_saturating(amount.clone())?; // Tolerates underflows (amount bigger than balance), but fails if there are no tokens at all for the denom (report potential errors)
             Ok(allowance)
         })?;
+
     if allowance.balance.is_empty() {
         ALLOWANCES.remove(deps.storage, &spender_addr);
     }
@@ -297,14 +326,16 @@ where
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::AdminList {} => to_binary(&query_admin_list(deps)?),
-        QueryMsg::Allowance { spender } => to_binary(&query_allowance(deps, spender)?),
+        QueryMsg::Allowance { spender } => to_binary(&query_allowance(deps, env, spender)?),
         QueryMsg::Permissions { spender } => to_binary(&query_permissions(deps, spender)?),
-        QueryMsg::CanExecute { sender, msg } => to_binary(&query_can_execute(deps, sender, msg)?),
+        QueryMsg::CanExecute { sender, msg } => {
+            to_binary(&query_can_execute(deps, env, sender, msg)?)
+        }
         QueryMsg::AllAllowances { start_after, limit } => {
-            to_binary(&query_all_allowances(deps, start_after, limit)?)
+            to_binary(&query_all_allowances(deps, env, start_after, limit)?)
         }
         QueryMsg::AllPermissions { start_after, limit } => {
             to_binary(&query_all_permissions(deps, start_after, limit)?)
@@ -313,12 +344,14 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 // if the subkey has no allowance, return an empty struct (not an error)
-pub fn query_allowance(deps: Deps, spender: String) -> StdResult<Allowance> {
+pub fn query_allowance(deps: Deps, env: Env, spender: String) -> StdResult<Allowance> {
     // we can use unchecked here as it is a query - bad value means a miss, we never write it
     let spender = deps.api.addr_validate(&spender)?;
     let allow = ALLOWANCES
         .may_load(deps.storage, &spender)?
+        .filter(|allow| !is_expired(&env, allow.expires))
         .unwrap_or_default();
+
     Ok(allow)
 }
 
@@ -331,14 +364,19 @@ pub fn query_permissions(deps: Deps, spender: String) -> StdResult<Permissions> 
     Ok(permissions)
 }
 
-fn query_can_execute(deps: Deps, sender: String, msg: CosmosMsg) -> StdResult<CanExecuteResponse> {
+fn query_can_execute(
+    deps: Deps,
+    env: Env,
+    sender: String,
+    msg: CosmosMsg,
+) -> StdResult<CanExecuteResponse> {
     Ok(CanExecuteResponse {
-        can_execute: can_execute(deps, sender, msg)?,
+        can_execute: can_execute(deps, env, sender, msg)?,
     })
 }
 
 // this can just return booleans and the query_can_execute wrapper creates the struct once, not on every path
-fn can_execute(deps: Deps, sender: String, msg: CosmosMsg) -> StdResult<bool> {
+fn can_execute(deps: Deps, env: Env, sender: String, msg: CosmosMsg) -> StdResult<bool> {
     let cfg = ADMIN_LIST.load(deps.storage)?;
     if cfg.is_admin(&sender) {
         return Ok(true);
@@ -351,7 +389,9 @@ fn can_execute(deps: Deps, sender: String, msg: CosmosMsg) -> StdResult<bool> {
             let allowance = ALLOWANCES.may_load(deps.storage, &sender)?;
             match allowance {
                 // if there is an allowance, we subtract the requested amount to ensure it is covered (error on underflow)
-                Some(allow) => Ok(allow.balance.sub(amount).is_ok()),
+                Some(allow) => {
+                    Ok(!is_expired(&env, allow.expires) && allow.balance.sub(amount).is_ok())
+                }
                 None => Ok(false),
             }
         }
@@ -385,6 +425,7 @@ fn calc_limit(request: Option<u32>) -> usize {
 // return a list of all allowances here
 pub fn query_all_allowances(
     deps: Deps,
+    env: Env,
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> StdResult<AllAllowancesResponse> {
@@ -394,6 +435,13 @@ pub fn query_all_allowances(
 
     let res: StdResult<Vec<AllowanceInfo>> = ALLOWANCES
         .range(deps.storage, start, None, Order::Ascending)
+        .filter(|item| {
+            if let Ok((_, allow)) = item {
+                !is_expired(&env, allow.expires)
+            } else {
+                true
+            }
+        })
         .take(limit)
         .map(|item| {
             item.and_then(|(k, allow)| {
@@ -457,6 +505,7 @@ mod tests {
     const SPENDER1: &str = "spender1";
     const SPENDER2: &str = "spender2";
     const SPENDER3: &str = "spender3";
+    const SPENDER4: &str = "spender4";
 
     const TOKEN: &str = "token";
     const TOKEN1: &str = "token1";
@@ -474,6 +523,14 @@ mod tests {
         undelegate: false,
         withdraw: false,
     };
+
+    // Expiration constant working properly with default `mock_env`
+    const NON_EXPIRED_HEIGHT: Expiration = Expiration::AtHeight(22_222);
+    const NON_EXPIRED_TIME: Expiration =
+        Expiration::AtTime(Timestamp::from_nanos(2_571_797_419_879_305_533));
+
+    const EXPIRED_HEIGHT: Expiration = Expiration::AtHeight(10);
+    const EXPIRED_TIME: Expiration = Expiration::AtTime(Timestamp::from_nanos(100));
 
     /// Helper structure for Suite configuration
     #[derive(Default)]
@@ -582,7 +639,13 @@ mod tests {
                         amount,
                         expires,
                     };
-                    execute(deps.as_mut().branch(), mock_env(), owner.clone(), msg).unwrap();
+
+                    // Extend block and time, so all alowances are set, even if expired in normal
+                    // mock_env
+                    let mut env = mock_env();
+                    env.block.time = Timestamp::from_nanos(0);
+                    env.block.height = 0;
+                    execute(deps.as_mut().branch(), env, owner.clone(), msg).unwrap();
                 }
 
                 if let Some(permissions) = permissions {
@@ -642,7 +705,8 @@ mod tests {
                 .init();
 
             // Check allowances work for accounts with balances
-            let allowance = query_allowance(deps.as_ref(), SPENDER1.to_owned()).unwrap();
+            let allowance =
+                query_allowance(deps.as_ref(), mock_env(), SPENDER1.to_owned()).unwrap();
             assert_eq!(
                 allowance,
                 Allowance {
@@ -650,7 +714,8 @@ mod tests {
                     expires: Expiration::Never {},
                 }
             );
-            let allowance = query_allowance(deps.as_ref(), SPENDER2.to_owned()).unwrap();
+            let allowance =
+                query_allowance(deps.as_ref(), mock_env(), SPENDER2.to_owned()).unwrap();
             assert_eq!(
                 allowance,
                 Allowance {
@@ -660,8 +725,28 @@ mod tests {
             );
 
             // Check allowances work for accounts with no balance
-            let allowance = query_allowance(deps.as_ref(), SPENDER3.to_string()).unwrap();
+            let allowance =
+                query_allowance(deps.as_ref(), mock_env(), SPENDER3.to_string()).unwrap();
             assert_eq!(allowance, Allowance::default());
+        }
+
+        #[test]
+        fn query_expired() {
+            let Suite { deps, .. } = SuiteConfig::new()
+                .with_allowance(SPENDER1, coin(1, TOKEN))
+                .expire_allowances(SPENDER1, EXPIRED_HEIGHT)
+                .init();
+
+            // Check allowances work for accounts with balances
+            let allowance =
+                query_allowance(deps.as_ref(), mock_env(), SPENDER1.to_owned()).unwrap();
+            assert_eq!(
+                allowance,
+                Allowance {
+                    balance: NativeBalance(vec![]),
+                    expires: Expiration::Never {},
+                }
+            );
         }
 
         #[test]
@@ -671,14 +756,17 @@ mod tests {
             let s3_allow = coin(3456, TOKEN);
 
             let s2_expire = Expiration::Never {};
-            let s3_expire = Expiration::AtHeight(12345);
+            let s3_expire = NON_EXPIRED_HEIGHT;
 
             let Suite { deps, .. } = SuiteConfig::new()
                 .with_allowance(SPENDER1, s1_allow.clone())
                 .with_allowance(SPENDER2, s2_allow.clone())
-                .expire_allowances(SPENDER2, Expiration::Never {})
+                .expire_allowances(SPENDER2, s2_expire)
                 .with_allowance(SPENDER3, s3_allow.clone())
-                .expire_allowances(SPENDER3, Expiration::AtHeight(12345))
+                .expire_allowances(SPENDER3, s3_expire)
+                // This allowance is already expired - should not occur in result
+                .with_allowance(SPENDER4, coin(2222, TOKEN))
+                .expire_allowances(SPENDER4, EXPIRED_HEIGHT)
                 .init();
 
             // let's try pagination.
@@ -687,16 +775,20 @@ mod tests {
             // dependent at least on ordering of insertions), so to check if pagination works, all what
             // can we do is to ensure parts are of expected size, and that collectively all allowances
             // are returned.
-            let batch1 = query_all_allowances(deps.as_ref(), None, Some(2))
+            let batch1 = query_all_allowances(deps.as_ref(), mock_env(), None, Some(2))
                 .unwrap()
                 .allowances;
             assert_eq!(2, batch1.len());
 
             // now continue from after the last one
-            let batch2 =
-                query_all_allowances(deps.as_ref(), Some(batch1[1].spender.clone()), Some(2))
-                    .unwrap()
-                    .allowances;
+            let batch2 = query_all_allowances(
+                deps.as_ref(),
+                mock_env(),
+                Some(batch1[1].spender.clone()),
+                Some(2),
+            )
+            .unwrap()
+            .allowances;
             assert_eq!(1, batch2.len());
 
             let expected = vec![
@@ -960,7 +1052,7 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
@@ -992,7 +1084,7 @@ mod tests {
                 ExecuteMsg::IncreaseAllowance {
                     spender: SPENDER1.to_owned(),
                     amount: coin(3, TOKEN1),
-                    expires: Some(Expiration::AtHeight(10)),
+                    expires: Some(NON_EXPIRED_HEIGHT),
                 },
             )
             .unwrap();
@@ -1002,14 +1094,14 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
                     allowances: vec![AllowanceInfo {
                         spender: SPENDER1.to_owned(),
                         balance: NativeBalance(vec![coin(4, TOKEN1)]),
-                        expires: Expiration::AtHeight(10),
+                        expires: NON_EXPIRED_HEIGHT,
                     }]
                 }
                 .canonical()
@@ -1041,7 +1133,7 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
@@ -1080,7 +1172,7 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
@@ -1109,9 +1201,6 @@ mod tests {
                 .with_allowance(SPENDER1, coin(1, TOKEN1))
                 .init();
 
-            let mut env = mock_env();
-            env.block.height = 2;
-
             let rsp = execute(
                 deps.as_mut(),
                 mock_env(),
@@ -1119,7 +1208,7 @@ mod tests {
                 ExecuteMsg::IncreaseAllowance {
                     spender: SPENDER2.to_owned(),
                     amount: coin(3, TOKEN1),
-                    expires: Some(Expiration::AtHeight(4)),
+                    expires: Some(NON_EXPIRED_HEIGHT),
                 },
             )
             .unwrap();
@@ -1129,7 +1218,7 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
@@ -1142,9 +1231,85 @@ mod tests {
                         AllowanceInfo {
                             spender: SPENDER2.to_owned(),
                             balance: NativeBalance(vec![coin(3, TOKEN1)]),
-                            expires: Expiration::AtHeight(4),
+                            expires: NON_EXPIRED_HEIGHT,
                         }
                     ]
+                }
+                .canonical(),
+            );
+        }
+
+        #[test]
+        fn previous_expired() {
+            let Suite {
+                mut deps, owner, ..
+            } = SuiteConfig::new()
+                .with_allowance(SPENDER1, coin(1, TOKEN1))
+                .expire_allowances(SPENDER1, EXPIRED_HEIGHT)
+                .init();
+
+            let rsp = execute(
+                deps.as_mut(),
+                mock_env(),
+                owner,
+                ExecuteMsg::IncreaseAllowance {
+                    spender: SPENDER1.to_owned(),
+                    amount: coin(2, TOKEN2),
+                    expires: Some(NON_EXPIRED_TIME),
+                },
+            )
+            .unwrap();
+
+            assert_eq!(rsp.messages, vec![]);
+            assert_eq!(rsp.events, vec![]);
+            assert_eq!(rsp.data, None);
+
+            assert_eq!(
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
+                    .unwrap()
+                    .canonical(),
+                AllAllowancesResponse {
+                    allowances: vec![AllowanceInfo {
+                        spender: SPENDER1.to_owned(),
+                        balance: NativeBalance(vec![coin(2, TOKEN2)]),
+                        expires: NON_EXPIRED_TIME,
+                    }]
+                }
+                .canonical(),
+            );
+        }
+
+        #[test]
+        fn set_expired() {
+            let Suite {
+                mut deps, owner, ..
+            } = SuiteConfig::new()
+                .with_allowance(SPENDER1, coin(1, TOKEN1))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
+                .init();
+
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                owner,
+                ExecuteMsg::IncreaseAllowance {
+                    spender: SPENDER1.to_owned(),
+                    amount: coin(2, TOKEN2),
+                    expires: Some(EXPIRED_TIME),
+                },
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
+                    .unwrap()
+                    .canonical(),
+                AllAllowancesResponse {
+                    allowances: vec![AllowanceInfo {
+                        spender: SPENDER1.to_owned(),
+                        balance: NativeBalance(vec![coin(1, TOKEN1)]),
+                        expires: NON_EXPIRED_HEIGHT,
+                    }]
                 }
                 .canonical(),
             );
@@ -1163,7 +1328,7 @@ mod tests {
                 mut deps, owner, ..
             } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
-                .expire_allowances(SPENDER1, Expiration::AtHeight(4))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
                 .init();
 
             let rsp = execute(
@@ -1183,14 +1348,14 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
                     allowances: vec![AllowanceInfo {
                         spender: SPENDER1.to_owned(),
                         balance: NativeBalance(vec![coin(6, TOKEN1)]),
-                        expires: Expiration::AtHeight(4),
+                        expires: NON_EXPIRED_HEIGHT,
                     }]
                 }
                 .canonical()
@@ -1204,7 +1369,7 @@ mod tests {
             } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
                 .with_allowance(SPENDER1, coin(20, TOKEN2))
-                .expire_allowances(SPENDER1, Expiration::AtHeight(4))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
                 .init();
 
             let rsp = execute(
@@ -1224,14 +1389,14 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
                     allowances: vec![AllowanceInfo {
                         spender: SPENDER1.to_owned(),
                         balance: NativeBalance(vec![coin(20, TOKEN2)]),
-                        expires: Expiration::AtHeight(4),
+                        expires: NON_EXPIRED_HEIGHT,
                     }]
                 }
                 .canonical()
@@ -1245,7 +1410,7 @@ mod tests {
             } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
                 .with_allowance(SPENDER1, coin(20, TOKEN2))
-                .expire_allowances(SPENDER1, Expiration::AtHeight(4))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
                 .init();
 
             let rsp = execute(
@@ -1265,14 +1430,14 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
                     allowances: vec![AllowanceInfo {
                         spender: SPENDER1.to_owned(),
                         balance: NativeBalance(vec![coin(20, TOKEN2)]),
-                        expires: Expiration::AtHeight(4),
+                        expires: NON_EXPIRED_HEIGHT,
                     }]
                 }
                 .canonical()
@@ -1285,7 +1450,7 @@ mod tests {
                 mut deps, owner, ..
             } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
-                .expire_allowances(SPENDER1, Expiration::AtHeight(4))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
                 .init();
 
             let rsp = execute(
@@ -1305,7 +1470,7 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse { allowances: vec![] }.canonical()
@@ -1318,7 +1483,7 @@ mod tests {
                 mut deps, owner, ..
             } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
-                .expire_allowances(SPENDER1, Expiration::AtHeight(4))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
                 .init();
 
             let rsp = execute(
@@ -1328,7 +1493,7 @@ mod tests {
                 ExecuteMsg::DecreaseAllowance {
                     spender: SPENDER1.to_owned(),
                     amount: coin(4, TOKEN1),
-                    expires: Some(Expiration::AtHeight(10)),
+                    expires: Some(NON_EXPIRED_TIME),
                 },
             )
             .unwrap();
@@ -1338,14 +1503,14 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
                     allowances: vec![AllowanceInfo {
                         spender: SPENDER1.to_owned(),
                         balance: NativeBalance(vec![coin(6, TOKEN1)]),
-                        expires: Expiration::AtHeight(10),
+                        expires: NON_EXPIRED_TIME,
                     }]
                 }
                 .canonical()
@@ -1358,7 +1523,7 @@ mod tests {
                 mut deps, owner, ..
             } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
-                .expire_allowances(SPENDER1, Expiration::AtHeight(4))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
                 .init();
 
             execute(
@@ -1374,14 +1539,14 @@ mod tests {
             .unwrap_err();
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
                     allowances: vec![AllowanceInfo {
                         spender: SPENDER1.to_owned(),
                         balance: NativeBalance(vec![coin(10, TOKEN1)]),
-                        expires: Expiration::AtHeight(4),
+                        expires: NON_EXPIRED_HEIGHT,
                     }]
                 }
                 .canonical()
@@ -1409,7 +1574,7 @@ mod tests {
             .unwrap_err();
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
@@ -1420,6 +1585,71 @@ mod tests {
                     }]
                 }
                 .canonical()
+            );
+        }
+
+        #[test]
+        fn previous_expired() {
+            let Suite {
+                mut deps, owner, ..
+            } = SuiteConfig::new()
+                .with_allowance(SPENDER1, coin(3, TOKEN1))
+                .expire_allowances(SPENDER1, EXPIRED_HEIGHT)
+                .init();
+
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                owner,
+                ExecuteMsg::DecreaseAllowance {
+                    spender: SPENDER1.to_owned(),
+                    amount: coin(2, TOKEN1),
+                    expires: Some(NON_EXPIRED_TIME),
+                },
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
+                    .unwrap()
+                    .canonical(),
+                AllAllowancesResponse { allowances: vec![] }.canonical(),
+            );
+        }
+
+        #[test]
+        fn set_expired() {
+            let Suite {
+                mut deps, owner, ..
+            } = SuiteConfig::new()
+                .with_allowance(SPENDER1, coin(3, TOKEN1))
+                .expire_allowances(SPENDER1, NON_EXPIRED_HEIGHT)
+                .init();
+
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                owner,
+                ExecuteMsg::IncreaseAllowance {
+                    spender: SPENDER1.to_owned(),
+                    amount: coin(2, TOKEN1),
+                    expires: Some(EXPIRED_TIME),
+                },
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
+                    .unwrap()
+                    .canonical(),
+                AllAllowancesResponse {
+                    allowances: vec![AllowanceInfo {
+                        spender: SPENDER1.to_owned(),
+                        balance: NativeBalance(vec![coin(3, TOKEN1)]),
+                        expires: NON_EXPIRED_HEIGHT,
+                    }]
+                }
+                .canonical(),
             );
         }
     }
@@ -1457,7 +1687,7 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
@@ -1492,7 +1722,7 @@ mod tests {
             .unwrap_err();
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse { allowances: vec![] }.canonical()
@@ -1522,7 +1752,7 @@ mod tests {
             .unwrap_err();
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse {
@@ -1537,11 +1767,10 @@ mod tests {
         }
 
         #[test]
-        #[ignore]
         fn time_allowance_expired() {
             let Suite { mut deps, .. } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
-                .expire_allowances(SPENDER1, Expiration::AtTime(Timestamp::from_seconds(1000)))
+                .expire_allowances(SPENDER1, EXPIRED_TIME)
                 .init();
 
             let msgs = vec![BankMsg::Send {
@@ -1551,32 +1780,27 @@ mod tests {
             .into()];
 
             let info = mock_info(SPENDER1, &[]);
-            let mut env = mock_env();
-            env.block.time = Timestamp::from_seconds(400);
-
-            execute(deps.as_mut(), env, info, ExecuteMsg::Execute { msgs }).unwrap_err();
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::Execute { msgs },
+            )
+            .unwrap_err();
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
-                AllAllowancesResponse {
-                    allowances: vec![AllowanceInfo {
-                        spender: SPENDER1.to_owned(),
-                        balance: NativeBalance(vec![coin(4, TOKEN1)]),
-                        expires: Expiration::Never {},
-                    }]
-                }
-                .canonical()
+                AllAllowancesResponse { allowances: vec![] }.canonical()
             );
         }
 
         #[test]
-        #[ignore]
         fn height_allowance_expired() {
             let Suite { mut deps, .. } = SuiteConfig::new()
                 .with_allowance(SPENDER1, coin(10, TOKEN1))
-                .expire_allowances(SPENDER1, Expiration::AtHeight(3))
+                .expire_allowances(SPENDER1, EXPIRED_HEIGHT)
                 .init();
 
             let msgs = vec![BankMsg::Send {
@@ -1586,23 +1810,19 @@ mod tests {
             .into()];
 
             let info = mock_info(SPENDER1, &[]);
-            let mut env = mock_env();
-            env.block.height = 10;
-
-            execute(deps.as_mut(), env, info, ExecuteMsg::Execute { msgs }).unwrap_err();
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::Execute { msgs },
+            )
+            .unwrap_err();
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
-                AllAllowancesResponse {
-                    allowances: vec![AllowanceInfo {
-                        spender: SPENDER1.to_owned(),
-                        balance: NativeBalance(vec![coin(4, TOKEN1)]),
-                        expires: Expiration::Never {},
-                    }]
-                }
-                .canonical()
+                AllAllowancesResponse { allowances: vec![] }.canonical()
             );
         }
 
@@ -1634,7 +1854,7 @@ mod tests {
             assert_eq!(rsp.data, None);
 
             assert_eq!(
-                query_all_allowances(deps.as_ref(), None, None)
+                query_all_allowances(deps.as_ref(), mock_env(), None, None)
                     .unwrap()
                     .canonical(),
                 AllAllowancesResponse { allowances: vec![] }.canonical()
@@ -1828,7 +2048,6 @@ mod tests {
         use super::*;
 
         #[test]
-        #[ignore]
         fn allowed() {
             let Suite { deps, .. } = SuiteConfig::new()
                 .with_permissions(SPENDER1, ALL_PERMS)
@@ -1854,7 +2073,8 @@ mod tests {
 
             for msg in msgs {
                 let resp =
-                    query_can_execute(deps.as_ref(), SPENDER1.to_owned(), msg.clone()).unwrap();
+                    query_can_execute(deps.as_ref(), mock_env(), SPENDER1.to_owned(), msg.clone())
+                        .unwrap();
 
                 assert_eq!(
                     resp,
@@ -1877,7 +2097,27 @@ mod tests {
             }
             .into();
 
-            let resp = query_can_execute(deps.as_ref(), SPENDER1.to_owned(), msg).unwrap();
+            let resp =
+                query_can_execute(deps.as_ref(), mock_env(), SPENDER1.to_owned(), msg).unwrap();
+
+            assert_eq!(resp, CanExecuteResponse { can_execute: false });
+        }
+
+        #[test]
+        fn expired_allowance() {
+            let Suite { deps, .. } = SuiteConfig::new()
+                .with_allowance(SPENDER1, coin(10, TOKEN1))
+                .expire_allowances(SPENDER1, EXPIRED_TIME)
+                .init();
+
+            let msg: CosmosMsg = BankMsg::Send {
+                to_address: SPENDER2.to_owned(),
+                amount: coins(5, TOKEN1),
+            }
+            .into();
+
+            let resp =
+                query_can_execute(deps.as_ref(), mock_env(), SPENDER1.to_owned(), msg).unwrap();
 
             assert_eq!(resp, CanExecuteResponse { can_execute: false });
         }
@@ -1902,7 +2142,8 @@ mod tests {
 
             for msg in msgs {
                 let resp =
-                    query_can_execute(deps.as_ref(), SPENDER1.to_owned(), msg.clone()).unwrap();
+                    query_can_execute(deps.as_ref(), mock_env(), SPENDER1.to_owned(), msg.clone())
+                        .unwrap();
 
                 assert_eq!(
                     resp,
@@ -1921,7 +2162,8 @@ mod tests {
 
             let msg: CosmosMsg = CosmosMsg::Custom(Empty {});
 
-            let resp = query_can_execute(deps.as_ref(), SPENDER1.to_owned(), msg).unwrap();
+            let resp =
+                query_can_execute(deps.as_ref(), mock_env(), SPENDER1.to_owned(), msg).unwrap();
 
             assert_eq!(resp, CanExecuteResponse { can_execute: false });
         }
@@ -1950,7 +2192,8 @@ mod tests {
 
             for msg in msgs {
                 let resp =
-                    query_can_execute(deps.as_ref(), ADMIN1.to_owned(), msg.clone()).unwrap();
+                    query_can_execute(deps.as_ref(), mock_env(), ADMIN1.to_owned(), msg.clone())
+                        .unwrap();
 
                 assert_eq!(
                     resp,
@@ -2012,7 +2255,7 @@ mod tests {
 
         let res_perm = query_permissions(deps.as_ref(), spender1.to_string()).unwrap();
         assert_eq!(perm, res_perm);
-        let res_allow = query_allowance(deps.as_ref(), spender1.to_string()).unwrap();
+        let res_allow = query_allowance(deps.as_ref(), mock_env(), spender1.to_string()).unwrap();
         assert_eq!(allow, res_allow);
 
         // setup allowance and then permission and check if changed
@@ -2031,7 +2274,7 @@ mod tests {
 
         let res_perm = query_permissions(deps.as_ref(), spender2.to_string()).unwrap();
         assert_eq!(perm, res_perm);
-        let res_allow = query_allowance(deps.as_ref(), spender2.to_string()).unwrap();
+        let res_allow = query_allowance(deps.as_ref(), mock_env(), spender2.to_string()).unwrap();
         assert_eq!(allow, res_allow);
     }
 }

--- a/contracts/cw1-subkeys/src/error.rs
+++ b/contracts/cw1-subkeys/src/error.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::StdError;
+use cw0::Expiration;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -38,6 +39,9 @@ pub enum ContractError {
 
     #[error("Unsupported message")]
     UnsupportedMessage {},
+
+    #[error("Allowance already expired while setting: {0}")]
+    SettingExpiredAllowance(Expiration),
 }
 
 impl From<cw1_whitelist::ContractError> for ContractError {


### PR DESCRIPTION
There is one edge case which is not clean - what to do, when previous allowance is expired, but no new allowance is set. There are two reasonable solutions:

* treat previous expired allowance as no allowance, so missing allowance in `IncreaseAllowance` in such case would just set expiration to `Expire::Never {}` as it is default expiration for new allowances. This feels natural, but might cause dangerous usecase: if transaction was scheduled before previous allowance expired, then probably he expected it not to change, but it would change, if transaction would be validated to late (and it would be never expiring)
* behave, as it would be setting allowance which is already expired - return an error - this seems to be way more reasonable

This obviously doesn't impact decreasing allowance, as decreasing non existing allowance is always an error (nothing to decrease).