### PR TITLE
Extend `ContractData` in multi-test

### DIFF
--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -728,7 +728,7 @@ mod test {
         // verify contract data are as expected
         let contract_data = CONTRACTS
             .load(
-                &prefixed_read(&mut wasm_storage, NAMESPACE_WASM),
+                &prefixed_read(&wasm_storage, NAMESPACE_WASM),
                 &contract_addr,
             )
             .unwrap();

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -28,10 +28,15 @@ pub const NAMESPACE_WASM: &[u8] = b"wasm";
 /// interface.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 struct ContractData {
+    /// Identifier of stored contract code
     pub code_id: usize,
+    /// Address of node who initially instantiated the contract
     pub creator: Addr,
+    /// Optional address of node who can execute migrations
     pub admin: Option<Addr>,
+    /// Optional metadata passed while contract instantiation
     pub label: String,
+    /// Blockchain height in the moment of instanciating the contract
     pub created: u64,
 }
 


### PR DESCRIPTION
One thing I would like to improve later about this is to make unit test to actually using `Wasm<C>` interface instead of internal private functions.

There are two reasons for that: 

1. Such tests would be more stable so easier to maintain - internal private functions and layouts might change as it is their nature, but every such change requires tests update. Public API (which `Wasm<C>` is for `WasmKeeper`) should probably not change almost at all (possibly might be extended, but unless some serious breaking change is made, it should not affect existing code, including tests).

2. `Wasm<C>` implementation of `WasmKeeper` are not just recalls to internall private functions, they actually have some orchestration logic. Testing basing on private calls, completely excludes this functonality from being tested.