### PR TITLE
Abstracting API out of tests internals so it is clearly owned by `App`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.14.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01127cb8617e5e21bcf2e19b5eb48317735ca677f1d0a94833c21c331c446582"
+checksum = "c5446d1cf2dfe2d6367c8b27f2082bdf011e60e76fa1fcd140047f535156d6e7"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",

--- a/contracts/cw20-escrow/src/integration_test.rs
+++ b/contracts/cw20-escrow/src/integration_test.rs
@@ -9,10 +9,10 @@ use crate::msg::{CreateMsg, DetailsResponse, ExecuteMsg, InstantiateMsg, QueryMs
 
 fn mock_app() -> App {
     let env = mock_env();
-    let api = Box::new(MockApi::default());
+    let api = MockApi::default();
     let bank = BankKeeper::new();
 
-    App::new(api, env.block, bank, Box::new(MockStorage::new()))
+    App::new(api, env.block, bank, MockStorage::new())
 }
 
 pub fn contract_escrow() -> Box<dyn Contract<Empty>> {

--- a/contracts/cw3-fixed-multisig/src/integration_tests.rs
+++ b/contracts/cw3-fixed-multisig/src/integration_tests.rs
@@ -12,10 +12,10 @@ use cw_multi_test::{App, BankKeeper, Contract, ContractWrapper, Executor};
 
 fn mock_app() -> App {
     let env = mock_env();
-    let api = Box::new(MockApi::default());
+    let api = MockApi::default();
     let bank = BankKeeper::new();
 
-    App::new(api, env.block, bank, Box::new(MockStorage::new()))
+    App::new(api, env.block, bank, MockStorage::new())
 }
 
 pub fn contract_cw3_fixed_multisig() -> Box<dyn Contract<Empty>> {

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -471,10 +471,10 @@ mod tests {
 
     fn mock_app() -> App {
         let env = mock_env();
-        let api = Box::new(MockApi::default());
+        let api = MockApi::default();
         let bank = BankKeeper::new();
 
-        App::new(api, env.block, bank, Box::new(MockStorage::new()))
+        App::new(api, env.block, bank, MockStorage::new())
     }
 
     // uploads code and returns address of group contract

--- a/packages/multi-test/clippy.toml
+++ b/packages/multi-test/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    coin, to_binary, Addr, AllBalanceResponse, BalanceResponse, BankMsg, BankQuery, Binary, Coin,
-    Event, Storage,
+    coin, to_binary, Addr, AllBalanceResponse, Api, BalanceResponse, BankMsg, BankQuery, Binary,
+    Coin, Event, Storage,
 };
 
 use crate::executor::AppResponse;
@@ -23,7 +23,12 @@ pub trait Bank {
         msg: BankMsg,
     ) -> Result<AppResponse, String>;
 
-    fn query(&self, storage: &dyn Storage, request: BankQuery) -> Result<Binary, String>;
+    fn query(
+        &self,
+        api: &dyn Api,
+        storage: &dyn Storage,
+        request: BankQuery,
+    ) -> Result<Binary, String>;
 
     // Admin interface
     fn init_balance(
@@ -136,18 +141,23 @@ impl Bank for BankKeeper {
         }
     }
 
-    fn query(&self, storage: &dyn Storage, request: BankQuery) -> Result<Binary, String> {
+    fn query(
+        &self,
+        api: &dyn Api,
+        storage: &dyn Storage,
+        request: BankQuery,
+    ) -> Result<Binary, String> {
         let bank_storage = prefixed_read(storage, NAMESPACE_BANK);
         match request {
             BankQuery::AllBalances { address } => {
-                // TODO: shall we pass in Api to make this safer?
-                let amount = self.get_balance(&bank_storage, &Addr::unchecked(address))?;
+                let address = api.addr_validate(&address).map_err(|err| err.to_string())?;
+                let amount = self.get_balance(&bank_storage, &address)?;
                 let res = AllBalanceResponse { amount };
                 Ok(to_binary(&res).map_err(|e| e.to_string())?)
             }
             BankQuery::Balance { address, denom } => {
-                // TODO: shall we pass in Api to make this safer?
-                let all_amounts = self.get_balance(&bank_storage, &Addr::unchecked(address))?;
+                let address = api.addr_validate(&address).map_err(|err| err.to_string())?;
+                let all_amounts = self.get_balance(&bank_storage, &address)?;
                 let amount = all_amounts
                     .into_iter()
                     .find(|c| c.denom == denom)
@@ -175,20 +185,26 @@ impl Bank for BankKeeper {
 mod test {
     use super::*;
 
-    use cosmwasm_std::testing::MockStorage;
+    use cosmwasm_std::testing::{MockApi, MockStorage};
     use cosmwasm_std::{coins, from_slice};
 
-    fn query_balance(bank: &BankKeeper, store: &dyn Storage, rcpt: &Addr) -> Vec<Coin> {
+    fn query_balance(
+        bank: &BankKeeper,
+        api: &dyn Api,
+        store: &dyn Storage,
+        rcpt: &Addr,
+    ) -> Vec<Coin> {
         let req = BankQuery::AllBalances {
             address: rcpt.clone().into(),
         };
-        let raw = bank.query(store, req).unwrap();
+        let raw = bank.query(api, store, req).unwrap();
         let res: AllBalanceResponse = from_slice(&raw).unwrap();
         res.amount
     }
 
     #[test]
     fn get_set_balance() {
+        let api = MockApi::default();
         let mut store = MockStorage::new();
 
         let owner = Addr::unchecked("owner");
@@ -211,14 +227,14 @@ mod test {
         let req = BankQuery::AllBalances {
             address: owner.clone().into(),
         };
-        let raw = bank.query(&store, req).unwrap();
+        let raw = bank.query(&api, &store, req).unwrap();
         let res: AllBalanceResponse = from_slice(&raw).unwrap();
         assert_eq!(res.amount, norm);
 
         let req = BankQuery::AllBalances {
             address: rcpt.clone().into(),
         };
-        let raw = bank.query(&store, req).unwrap();
+        let raw = bank.query(&api, &store, req).unwrap();
         let res: AllBalanceResponse = from_slice(&raw).unwrap();
         assert_eq!(res.amount, vec![]);
 
@@ -226,7 +242,7 @@ mod test {
             address: owner.clone().into(),
             denom: "eth".into(),
         };
-        let raw = bank.query(&store, req).unwrap();
+        let raw = bank.query(&api, &store, req).unwrap();
         let res: BalanceResponse = from_slice(&raw).unwrap();
         assert_eq!(res.amount, coin(100, "eth"));
 
@@ -234,7 +250,7 @@ mod test {
             address: owner.into(),
             denom: "foobar".into(),
         };
-        let raw = bank.query(&store, req).unwrap();
+        let raw = bank.query(&api, &store, req).unwrap();
         let res: BalanceResponse = from_slice(&raw).unwrap();
         assert_eq!(res.amount, coin(0, "foobar"));
 
@@ -242,13 +258,14 @@ mod test {
             address: rcpt.into(),
             denom: "eth".into(),
         };
-        let raw = bank.query(&store, req).unwrap();
+        let raw = bank.query(&api, &store, req).unwrap();
         let res: BalanceResponse = from_slice(&raw).unwrap();
         assert_eq!(res.amount, coin(0, "eth"));
     }
 
     #[test]
     fn send_coins() {
+        let api = MockApi::default();
         let mut store = MockStorage::new();
 
         let owner = Addr::unchecked("owner");
@@ -269,9 +286,9 @@ mod test {
         };
         bank.execute(&mut store, owner.clone(), msg.clone())
             .unwrap();
-        let rich = query_balance(&bank, &store, &owner);
+        let rich = query_balance(&bank, &api, &store, &owner);
         assert_eq!(vec![coin(15, "btc"), coin(70, "eth")], rich);
-        let poor = query_balance(&bank, &store, &rcpt);
+        let poor = query_balance(&bank, &api, &store, &rcpt);
         assert_eq!(vec![coin(10, "btc"), coin(30, "eth")], poor);
 
         // can send from any account with funds
@@ -284,12 +301,13 @@ mod test {
         };
         bank.execute(&mut store, owner.clone(), msg).unwrap_err();
 
-        let rich = query_balance(&bank, &store, &owner);
+        let rich = query_balance(&bank, &api, &store, &owner);
         assert_eq!(vec![coin(15, "btc"), coin(70, "eth")], rich);
     }
 
     #[test]
     fn burn_coins() {
+        let api = MockApi::default();
         let mut store = MockStorage::new();
 
         let owner = Addr::unchecked("owner");
@@ -304,7 +322,7 @@ mod test {
         let to_burn = vec![coin(30, "eth"), coin(5, "btc")];
         let msg = BankMsg::Burn { amount: to_burn };
         bank.execute(&mut store, owner.clone(), msg).unwrap();
-        let rich = query_balance(&bank, &store, &owner);
+        let rich = query_balance(&bank, &api, &store, &owner);
         assert_eq!(vec![coin(15, "btc"), coin(70, "eth")], rich);
 
         // cannot burn too much
@@ -313,7 +331,7 @@ mod test {
         };
         let err = bank.execute(&mut store, owner.clone(), msg).unwrap_err();
         assert!(err.contains("Overflow"));
-        let rich = query_balance(&bank, &store, &owner);
+        let rich = query_balance(&bank, &api, &store, &owner);
         assert_eq!(vec![coin(15, "btc"), coin(70, "eth")], rich);
 
         // cannot burn from empty account


### PR DESCRIPTION
closes #353

The reason behind whole change is that `Router` (or `WasmKeeper`) is no longer the only user of `Api`.

The easy way is to keep `Api` in `Rc`, and besides my worries about that, I tried this solution. Unfortunately `BankKeeper` which is eager to use `Api` is passed to `App` after it is configured, so it would require exposing information that things are `Rc` internally to the world, which I don't like, as it allows creator of `App` to keep his copy of `App`, and I don't like idea that `App` is nevermore owner of `Api`. I would probably go this way if only I would be able to keep `App::new` just taking `Api` with ownership - I even found a way, but it overcomplicates internals.

Another shot is instead of keeping `Api` internal for `App`, just take it there as a borrow, and deal this borrow to another users. Unfortunately it doesn't have too much upsides - app still is nevermore clean owner of `Api`, and lifetimes bounds everywhere makes thinks slightly less clean, which is not needed to happen in tests.

Also it is possible to just clone `Api` around, as it is pretty much trivial, but it would make it less flexible to extend it in future.

I took a way, where `Api` is just passed to relevant calls, just like `Storage` and other utilities. This isolates everything nicely, doesn't affect usage, and is very consistent with other interfaces.