### PR TITLE
Properly fold results

### DIFF
--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -715,11 +715,12 @@ mod test {
         // ensure data is empty
         assert_eq!(res.data, None);
         // ensure expected events
-        assert_eq!(res.events.len(), 2);
+        assert_eq!(res.events.len(), 3, "{:?}", res.events);
         // TODO: update with new events
         // ["execute", "execute", "wasm-echo", "reply"],
         assert_eq!("wasm", &res.events[0].ty);
-        assert_eq!("wasm-echo", &res.events[1].ty);
+        assert_eq!("wasm", &res.events[1].ty);
+        assert_eq!("wasm-echo", &res.events[2].ty);
     }
 
     #[test]

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -709,17 +709,16 @@ mod test {
         };
 
         let res = app
-            .execute_contract(owner.clone(), reflect_addr.clone(), &reflect_msg, &[])
+            .execute_contract(owner, reflect_addr, &reflect_msg, &[])
             .unwrap();
 
         // ensure data is empty
         assert_eq!(res.data, None);
         // ensure expected events
-        assert_eq!(res.events.len(), 4, "{:?}", res.events);
+        assert_eq!(res.events.len(), 3, "{:?}", res.events);
         assert_eq!("execute", &res.events[0].ty);
         assert_eq!("execute", &res.events[1].ty);
         assert_eq!("wasm-echo", &res.events[2].ty);
-        assert_eq!("reply", &res.events[1].ty);
     }
 
     #[test]
@@ -754,7 +753,7 @@ mod test {
         };
 
         let res = app
-            .execute_contract(owner.clone(), echo_addr.clone(), &top_msg, &[])
+            .execute_contract(owner, echo_addr, &top_msg, &[])
             .unwrap();
 
         // ensure data is set via reply
@@ -1236,7 +1235,7 @@ mod test {
                 )
                 .unwrap();
 
-            assert_eq!(response.data, Some("Second".as_bytes().into()));
+            assert_eq!(response.data, Some("Orig".as_bytes().into()));
         }
     }
 

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -1323,7 +1323,7 @@ mod test {
                 )
                 .unwrap();
 
-            assert_eq!(response.data, Some("Orig".as_bytes().into()));
+            assert_eq!(response.data, Some("Second".as_bytes().into()));
         }
     }
 

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -715,12 +715,11 @@ mod test {
         // ensure data is empty
         assert_eq!(res.data, None);
         // ensure expected events
-        assert_eq!(res.events.len(), 3, "{:?}", res.events);
-        // TODO: update with new events
-        // ["execute", "execute", "wasm-echo", "reply"],
-        assert_eq!("wasm", &res.events[0].ty);
-        assert_eq!("wasm", &res.events[1].ty);
+        assert_eq!(res.events.len(), 4, "{:?}", res.events);
+        assert_eq!("execute", &res.events[0].ty);
+        assert_eq!("execute", &res.events[1].ty);
         assert_eq!("wasm-echo", &res.events[2].ty);
+        assert_eq!("reply", &res.events[1].ty);
     }
 
     #[test]
@@ -762,10 +761,9 @@ mod test {
         assert_eq!(res.data.unwrap().as_slice(), b"inside");
         // ensure expected events
         assert_eq!(res.events.len(), 4, "{:?}", res.events);
-        // TODO: update with new events
-        assert_eq!("wasm", &res.events[0].ty);
+        assert_eq!("execute", &res.events[0].ty);
         assert_eq!("wasm-topmsg", &res.events[1].ty);
-        assert_eq!("wasm", &res.events[2].ty);
+        assert_eq!("execute", &res.events[2].ty);
         assert_eq!("wasm-submsg", &res.events[3].ty);
     }
 

--- a/packages/multi-test/src/test_helpers/contracts/echo.rs
+++ b/packages/multi-test/src/test_helpers/contracts/echo.rs
@@ -10,6 +10,8 @@ use cosmwasm_std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{test_helpers::EmptyMsg, Contract, ContractWrapper};
+use schemars::JsonSchema;
+use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Message {
@@ -70,5 +72,14 @@ fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, StdError> {
 
 pub fn contract() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(execute, instantiate, query).with_reply(reply);
+    Box::new(contract)
+}
+
+pub fn custom_contract<C>() -> Box<dyn Contract<C>>
+where
+    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+{
+    let contract = ContractWrapper::new_with_empty(execute, instantiate, query);
+    let contract = contract.with_reply_empty(reply);
     Box::new(contract)
 }

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -512,7 +512,12 @@ where
             let subres =
                 self.execute_submsg(api, router, storage, block, contract.clone(), resend)?;
             events.extend_from_slice(&subres.events);
-            Ok::<_, String>(subres.data.or(data))
+
+            if data.is_some() {
+                Ok::<_, String>(subres.data.or(data))
+            } else {
+                Ok(None)
+            }
         })?;
 
         Ok(AppResponse { events, data })

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -369,7 +369,11 @@ where
     /// All sequential calls to RouterCache will be one atomic unit (all commit or all fail).
     ///
     /// For normal use cases, you can use Router::execute() or Router::execute_multi().
-    /// This is designed to be handled internally as part of larger process flows.
+    /// This is designed to be used in dispatched messages inside the execute_wasm flow.
+    ///
+    /// It returns both the `AppResponse` but with `data` set only if reply was called, and it
+    /// returned some `data` - if anything is returned there submesage execution itself, it would
+    /// be dropped as it should never override original message response.
     fn execute_submsg(
         &self,
         api: &dyn Api,

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -511,13 +511,7 @@ where
                 self.execute_submsg(api, router, storage, block, contract.clone(), submsg)?;
 
             events.extend_from_slice(&subres.events);
-
-            // Data should be overwritten if and only if replay was actually called
-            if data.is_some() {
-                Ok::<_, String>(subres.data.or(data))
-            } else {
-                Ok(None)
-            }
+            Ok::<_, String>(subres.data.or(data))
         })?;
 
         Ok(AppResponse { events, data })


### PR DESCRIPTION
This shows an issue coming up with multi-test

If the top-level has a reply statement, it may return a new data to over-ride what was previously set with execute / instantiate / migrate.

However, if the submessage returns a result, but we don't set the data in reply, it *must not* override the top level reply.

This has lead to improper contract data being returned in some cases (one instantiate calls another instantiate, the second data is returned on the top level).

My "quick fix" here broke the reply-set-data functionality completely, and it seems a bit tricky to address. There is a broken test case however that should show a working solution when it passes.

@hashedone I'd be happy if you take a look and push to this branch if you see fit.